### PR TITLE
Omsorgsdager aleneomsorg: Registrere barn selv.

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/Barn.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/Barn.kt
@@ -10,7 +10,7 @@ import no.nav.k9.søknad.felles.personopplysninger.Barn as K9Barn
 
 class Barn(
     private val navn: String,
-    private val aktørId: String,
+    private val aktørId: String? = null,
     private var identitetsnummer: String? = null,
     private val tidspunktForAleneomsorg: TidspunktForAleneomsorg,
     private val dato: LocalDate? = null

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/Barn.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/Barn.kt
@@ -8,12 +8,20 @@ import no.nav.k9brukerdialogapi.oppslag.barn.BarnOppslag
 import java.time.LocalDate
 import no.nav.k9.søknad.felles.personopplysninger.Barn as K9Barn
 
+enum class TypeBarn{
+    FRA_OPPSLAG,
+    FOSTERBARN,
+    ANNET
+}
+
 class Barn(
     private val navn: String,
+    private val type: TypeBarn,
     private val aktørId: String? = null,
     private var identitetsnummer: String? = null,
     private val tidspunktForAleneomsorg: TidspunktForAleneomsorg,
-    private val dato: LocalDate? = null
+    private val dato: LocalDate? = null,
+    private val fødselsdato: LocalDate? = null
 ) {
     internal fun manglerIdentifikator() = identitetsnummer.isNullOrBlank()
 
@@ -60,6 +68,17 @@ class Barn(
                     parameterType = ParameterType.ENTITY,
                     reason = "Barn.dato kan ikke være tom dersom tidspunktForAleneomsorg er ${TidspunktForAleneomsorg.SISTE_2_ÅRENE.name}",
                     invalidValue = dato
+                )
+            )
+        }
+
+        if(type != TypeBarn.FRA_OPPSLAG && fødselsdato == null){
+            add(
+                Violation(
+                    parameterName = "barn.fødselsdato",
+                    parameterType = ParameterType.ENTITY,
+                    reason = "Barn som ikke stammer fra oppslag må ha fødselsdato satt.",
+                    invalidValue = fødselsdato
                 )
             )
         }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgTest.kt
@@ -17,6 +17,7 @@ import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import no.nav.k9brukerdialogapi.ytelse.omsorgsdageraleneomsorg.domene.Barn
 import no.nav.k9brukerdialogapi.ytelse.omsorgsdageraleneomsorg.domene.Søknad
 import no.nav.k9brukerdialogapi.ytelse.omsorgsdageraleneomsorg.domene.TidspunktForAleneomsorg
+import no.nav.k9brukerdialogapi.ytelse.omsorgsdageraleneomsorg.domene.TypeBarn
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.slf4j.Logger
@@ -85,6 +86,7 @@ class OmsorgsdagerAleneomsorgTest {
             barn = listOf(
                 Barn(
                     navn = "Barn1",
+                    type = TypeBarn.FRA_OPPSLAG,
                     aktørId = "123",
                     identitetsnummer = "25058118020",
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
@@ -116,6 +118,7 @@ class OmsorgsdagerAleneomsorgTest {
             barn = listOf(
                 Barn(
                     navn = " ",
+                    type = TypeBarn.FRA_OPPSLAG,
                     aktørId = "123",
                     identitetsnummer = null,
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/OmsorgsdagerAleneomsorgBarnTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/OmsorgsdagerAleneomsorgBarnTest.kt
@@ -26,6 +26,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
         )
         val barn = Barn(
             navn = "Barn uten identifikator",
+            type = TypeBarn.FRA_OPPSLAG,
             aktørId = "123",
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
             dato = LocalDate.parse("2022-01-01")
@@ -39,6 +40,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
     fun `Barn blir mappet til forventet K9Barn`(){
         val barn = Barn(
             navn = "Barn uten identifikator",
+            type = TypeBarn.FRA_OPPSLAG,
             aktørId = "123",
             identitetsnummer = "02119970078" ,
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
@@ -54,9 +56,11 @@ class OmsorgsdagerAleneomsorgBarnTest {
     }
 
     @Test
-    fun `Skal kunne opprette barn selv uten aktørId`(){
+    fun `Skal kunne registrere fosterbarn uten aktørId`(){
         val barn = Barn(
             navn = "Barn uten identifikator",
+            type = TypeBarn.FOSTERBARN,
+            fødselsdato = LocalDate.now().minusMonths(4),
             identitetsnummer = "02119970078" ,
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
         )
@@ -68,6 +72,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
     fun `Forvent valideringsfeil dersom norskIdentifikator er null`(){
         val barn = Barn(
             navn = "Barn uten identifikator",
+            type = TypeBarn.FRA_OPPSLAG,
             aktørId = "123",
             identitetsnummer = null ,
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
@@ -81,6 +86,7 @@ class OmsorgsdagerAleneomsorgBarnTest {
     fun `Forvent valideringsfeil dersom navn er blank`(){
         val barn = Barn(
             navn = " ",
+            type = TypeBarn.FRA_OPPSLAG,
             aktørId = "123",
             identitetsnummer = "02119970078" ,
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
@@ -92,9 +98,26 @@ class OmsorgsdagerAleneomsorgBarnTest {
     }
 
     @Test
+    fun `Forvent valideringsfeil dersom fødselsdato er null og barnet er fosterbarn`(){
+        val barn = Barn(
+            navn = "Navnesen",
+            type = TypeBarn.FOSTERBARN,
+            fødselsdato = null,
+            aktørId = "123",
+            identitetsnummer = "02119970078" ,
+            tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
+        )
+
+        val feil = barn.valider()
+        assertEquals(feil.first().reason, "Barn som ikke stammer fra oppslag må ha fødselsdato satt.")
+        assertEquals(1, feil.size)
+    }
+
+    @Test
     fun `Skal feile dersom tidspunktForAleneomsorg er siste 2 år, men dato er ikke satt`() {
         val barn = Barn(
             navn = "Barnesen",
+            type = TypeBarn.FRA_OPPSLAG,
             aktørId = "123",
             identitetsnummer = "02119970078" ,
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/OmsorgsdagerAleneomsorgBarnTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/OmsorgsdagerAleneomsorgBarnTest.kt
@@ -53,6 +53,16 @@ class OmsorgsdagerAleneomsorgBarnTest {
         JSONAssert.assertEquals(forventetK9Barn, JSONObject(barn.somK9Barn().somJson()), true)
     }
 
+    @Test
+    fun `Skal kunne opprette barn selv uten aktørId`(){
+        val barn = Barn(
+            navn = "Barn uten identifikator",
+            identitetsnummer = "02119970078" ,
+            tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
+        )
+        val feil = barn.valider()
+        assertTrue(feil.isEmpty())
+    }
 
     @Test
     fun `Forvent valideringsfeil dersom norskIdentifikator er null`(){

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/OmsorgsdagerAleneomsorgSøknadTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/domene/OmsorgsdagerAleneomsorgSøknadTest.kt
@@ -21,12 +21,14 @@ class OmsorgsdagerAleneomsorgSøknadTest {
             barn = listOf(
                 Barn(
                     navn = "Barn1",
+                    type = TypeBarn.FRA_OPPSLAG,
                     aktørId = "123",
                     identitetsnummer = null,
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
                 ),
                 Barn(
                     navn = "Barn2",
+                    type = TypeBarn.FRA_OPPSLAG,
                     aktørId = "1234",
                     identitetsnummer = null,
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
@@ -61,8 +63,8 @@ class OmsorgsdagerAleneomsorgSøknadTest {
 
     @Test
     fun `Søknad med to barn blir splittet opp i to ulike søknader per barn`(){
-        val barn1 = Barn("Barn1", "123", "12345", TidspunktForAleneomsorg.TIDLIGERE)
-        val barn2 = Barn("Barn2", "321", "54321", TidspunktForAleneomsorg.TIDLIGERE)
+        val barn1 = Barn("Barn1", TypeBarn.FRA_OPPSLAG, "123", "12345", TidspunktForAleneomsorg.TIDLIGERE)
+        val barn2 = Barn("Barn2", TypeBarn.FRA_OPPSLAG, "321", "54321", TidspunktForAleneomsorg.TIDLIGERE)
 
         val søknad = Søknad(
             barn = listOf(barn1, barn2),
@@ -93,6 +95,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
             barn = listOf(
                 Barn(
                     navn = "Barn1",
+                    type = TypeBarn.FRA_OPPSLAG,
                     aktørId = "123",
                     identitetsnummer = "25058118020",
                     tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE
@@ -140,6 +143,7 @@ class OmsorgsdagerAleneomsorgSøknadTest {
                 barn = listOf(
                     Barn(
                         navn = "Barn1",
+                        type = TypeBarn.FRA_OPPSLAG,
                         aktørId = "123",
                         identitetsnummer = "25058118020",
                         tidspunktForAleneomsorg = TidspunktForAleneomsorg.TIDLIGERE


### PR DESCRIPTION
Støtter at bruker kan legge til barn selv (fosterbarn eller annet) som ikke har aktørId. Må sette fødselsdato i stedet.

Fiks omsorgspenger midlertidig alene test 