### PR TITLE
Tilrettelegging for å forenkle å legge til støtte for oms-ut-snf

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/Bekreftelser.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/Bekreftelser.kt
@@ -1,4 +1,4 @@
-package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
+package no.nav.k9brukerdialogapi.ytelse.fellesdomene
 
 import no.nav.k9brukerdialogapi.general.krever
 

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/Bosted.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/Bosted.kt
@@ -1,4 +1,4 @@
-package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
+package no.nav.k9brukerdialogapi.ytelse.fellesdomene
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import no.nav.k9.søknad.felles.personopplysninger.Bosteder

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Arbeidsgiver.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Arbeidsgiver.kt
@@ -1,6 +1,5 @@
 package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
 
-import no.nav.k9.søknad.felles.fravær.AktivitetFravær
 import no.nav.k9.søknad.felles.fravær.SøknadÅrsak
 import no.nav.k9.søknad.felles.type.Organisasjonsnummer
 import no.nav.k9brukerdialogapi.general.krever
@@ -40,9 +39,8 @@ class Arbeidsgiver(
     }
 
     internal fun somK9Fraværsperiode() = perioder.map {
-        it.somFraværPeriode(
+        it.somFraværPeriodeForArbeidstaker(
             søknadÅrsak = utbetalingsårsak.somSøknadÅrsak(),
-            aktivitetFravær = listOf(AktivitetFravær.ARBEIDSTAKER),
             organisasjonsnummer = Organisasjonsnummer.of(organisasjonsnummer)
         )
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/KomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/KomplettSøknad.kt
@@ -2,6 +2,7 @@ package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.dome
 
 import no.nav.k9.søknad.Søknad
 import no.nav.k9brukerdialogapi.oppslag.søker.Søker
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
 import java.time.ZonedDateTime
 
 class KomplettSøknad(

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/KomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/KomplettSøknad.kt
@@ -3,6 +3,8 @@ package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.dome
 import no.nav.k9.søknad.Søknad
 import no.nav.k9brukerdialogapi.oppslag.søker.Søker
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Opphold
 import java.time.ZonedDateTime
 
 class KomplettSøknad(

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Søknad.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Søknad.kt
@@ -10,11 +10,13 @@ import no.nav.k9brukerdialogapi.general.krever
 import no.nav.k9brukerdialogapi.oppslag.søker.Søker
 import no.nav.k9brukerdialogapi.vedlegg.vedleggId
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted.Companion.somK9Bosteder
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted.Companion.somK9Utenlandsopphold
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted.Companion.valider
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Opphold
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Arbeidsgiver.Companion.somK9Fraværsperiode
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Arbeidsgiver.Companion.valider
-import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Bosted.Companion.somK9Bosteder
-import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Bosted.Companion.somK9Utenlandsopphold
-import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Bosted.Companion.valider
 import java.net.URL
 import java.time.ZoneOffset
 import java.time.ZonedDateTime

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Søknad.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Søknad.kt
@@ -9,6 +9,7 @@ import no.nav.k9brukerdialogapi.general.ValidationProblemDetails
 import no.nav.k9brukerdialogapi.general.krever
 import no.nav.k9brukerdialogapi.oppslag.søker.Søker
 import no.nav.k9brukerdialogapi.vedlegg.vedleggId
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Arbeidsgiver.Companion.somK9Fraværsperiode
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Arbeidsgiver.Companion.valider
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Bosted.Companion.somK9Bosteder

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Utbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Utbetalingsperiode.kt
@@ -1,7 +1,6 @@
 package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import no.nav.k9.søknad.felles.fravær.AktivitetFravær
 import no.nav.k9.søknad.felles.fravær.FraværPeriode
 import no.nav.k9.søknad.felles.fravær.SøknadÅrsak
 import no.nav.k9.søknad.felles.type.Organisasjonsnummer
@@ -11,6 +10,7 @@ import no.nav.k9brukerdialogapi.general.krever
 import no.nav.k9brukerdialogapi.general.kreverIkkeNull
 import java.time.Duration
 import java.time.LocalDate
+import no.nav.k9.søknad.felles.fravær.AktivitetFravær as K9AktivitetFravær
 import no.nav.k9.søknad.felles.fravær.FraværÅrsak as K9FraværÅrsak
 
 class Utbetalingsperiode(
@@ -18,7 +18,8 @@ class Utbetalingsperiode(
     @JsonFormat(pattern = "yyyy-MM-dd") private val tilOgMed: LocalDate,
     private val antallTimerBorte: Duration? = null,
     private val antallTimerPlanlagt: Duration? = null,
-    private val årsak: FraværÅrsak
+    private val årsak: FraværÅrsak,
+    private val aktivitetFravær: List<AktivitetFravær> = listOf()
 ) {
     companion object{
         internal fun List<Utbetalingsperiode>.valider(felt: String) = this.flatMapIndexed { index, periode ->
@@ -39,16 +40,15 @@ class Utbetalingsperiode(
         }
     }
 
-    internal fun somFraværPeriode(
+    internal fun somFraværPeriodeForArbeidstaker(
         søknadÅrsak: SøknadÅrsak,
-        aktivitetFravær: List<AktivitetFravær>,
         organisasjonsnummer: Organisasjonsnummer
     ) = FraværPeriode(
         Periode(fraOgMed, tilOgMed),
         antallTimerBorte,
         årsak.somK9FraværÅrsak(),
         søknadÅrsak,
-        aktivitetFravær,
+        listOf(AktivitetFravær.ARBEIDSTAKER.somK9AktivitetFravær()),
         organisasjonsnummer,
         null
     )
@@ -63,5 +63,17 @@ enum class FraværÅrsak {
         STENGT_SKOLE_ELLER_BARNEHAGE -> K9FraværÅrsak.STENGT_SKOLE_ELLER_BARNEHAGE
         SMITTEVERNHENSYN -> K9FraværÅrsak.SMITTEVERNHENSYN
         ORDINÆRT_FRAVÆR -> K9FraværÅrsak.ORDINÆRT_FRAVÆR
+    }
+}
+
+enum class AktivitetFravær {
+    ARBEIDSTAKER,
+    FRILANSER,
+    SELVSTENDIG_VIRKSOMHET;
+
+    fun somK9AktivitetFravær() = when(this){
+        ARBEIDSTAKER -> K9AktivitetFravær.ARBEIDSTAKER
+        FRILANSER -> K9AktivitetFravær.FRILANSER
+        SELVSTENDIG_VIRKSOMHET -> K9AktivitetFravær.SELVSTENDIG_VIRKSOMHET
     }
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Utbetalingsperiode.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Utbetalingsperiode.kt
@@ -19,6 +19,7 @@ class Utbetalingsperiode(
     private val antallTimerBorte: Duration? = null,
     private val antallTimerPlanlagt: Duration? = null,
     private val årsak: FraværÅrsak,
+    // TODO: 08/06/2022 Vurder om frontend kan endre til å sende med liste med Arbeidstaker, da slipper vi spesiell håndtering at snf sender men ikke arbeidstaker.
     private val aktivitetFravær: List<AktivitetFravær> = listOf()
 ) {
     companion object{

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/SøknadServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/SøknadServiceTest.kt
@@ -21,6 +21,7 @@ import no.nav.k9brukerdialogapi.vedlegg.VedleggService
 import no.nav.k9brukerdialogapi.ytelse.ettersending.EttersendingService
 import no.nav.k9brukerdialogapi.ytelse.ettersending.domene.Søknadstype
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Barn
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.OmsorgspengerUtbetalingArbeidstakerService
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.*
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutvidetrett.OmsorgspengerUtvidetRettService

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/BekreftelserTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/BekreftelserTest.kt
@@ -1,4 +1,4 @@
-package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
+package no.nav.k9brukerdialogapi.ytelse.fellesdomene
 
 import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.TestUtils.Companion.verifiserIngenFeil
@@ -7,7 +7,7 @@ import kotlin.test.Test
 class BekreftelserTest {
 
     @Test
-    fun `Feiler ikke om begge er true`() {
+    fun `Gyldig Bekreftelser gir ingen feil`() {
         Bekreftelser(
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true
@@ -23,10 +23,26 @@ class BekreftelserTest {
     }
 
     @Test
+    fun `Feiler om man sender harBekreftetOpplysninger som null`() {
+        Bekreftelser(
+            harBekreftetOpplysninger = null,
+            harForståttRettigheterOgPlikter = true
+        ).valider("bekreftelser").verifiserFeil(1, listOf("bekreftelser.harBekreftetOpplysninger må være true"))
+    }
+
+    @Test
     fun `Feiler om man sender harForståttRettigheterOgPlikter som false`() {
         Bekreftelser(
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = false
+        ).valider("bekreftelser").verifiserFeil(1, listOf("bekreftelser.harForståttRettigheterOgPlikter må være true"))
+    }
+
+    @Test
+    fun `Feiler om man sender harForståttRettigheterOgPlikter som null`() {
+        Bekreftelser(
+            harBekreftetOpplysninger = true,
+            harForståttRettigheterOgPlikter = null
         ).valider("bekreftelser").verifiserFeil(1, listOf("bekreftelser.harForståttRettigheterOgPlikter må være true"))
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/BostedOgOppholdTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/fellesdomene/BostedOgOppholdTest.kt
@@ -1,10 +1,10 @@
-package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
+package no.nav.k9brukerdialogapi.ytelse.fellesdomene
 
 import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.TestUtils.Companion.verifiserIngenFeil
 import no.nav.k9brukerdialogapi.somJson
-import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Bosted.Companion.somK9Bosteder
-import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Bosted.Companion.somK9Utenlandsopphold
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted.Companion.somK9Bosteder
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted.Companion.somK9Utenlandsopphold
 import org.skyscreamer.jsonassert.JSONAssert
 import java.time.LocalDate
 import kotlin.test.Test

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerTest.kt
@@ -14,6 +14,7 @@ import no.nav.k9brukerdialogapi.wiremock.stubK9Mellomlagring
 import no.nav.k9brukerdialogapi.wiremock.stubK9OppslagBarn
 import no.nav.k9brukerdialogapi.wiremock.stubK9OppslagSoker
 import no.nav.k9brukerdialogapi.ytelse.Ytelse
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.*
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerTest.kt
@@ -15,6 +15,8 @@ import no.nav.k9brukerdialogapi.wiremock.stubK9OppslagBarn
 import no.nav.k9brukerdialogapi.wiremock.stubK9OppslagSoker
 import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Opphold
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.*
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.jupiter.api.AfterAll

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
@@ -4,6 +4,7 @@ import no.nav.helse.dusseldorf.ktor.core.Throwblem
 import no.nav.k9brukerdialogapi.SøknadUtils
 import no.nav.k9brukerdialogapi.somJson
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted
 import org.junit.jupiter.api.assertThrows
 import org.skyscreamer.jsonassert.JSONAssert
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
@@ -3,6 +3,7 @@ package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.dome
 import no.nav.helse.dusseldorf.ktor.core.Throwblem
 import no.nav.k9brukerdialogapi.SøknadUtils
 import no.nav.k9brukerdialogapi.somJson
+import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bekreftelser
 import org.junit.jupiter.api.assertThrows
 import org.skyscreamer.jsonassert.JSONAssert
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/UtbetalingsperiodeTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/UtbetalingsperiodeTest.kt
@@ -2,7 +2,6 @@ package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.dome
 
 import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.TestUtils.Companion.verifiserIngenFeil
-import no.nav.k9.søknad.felles.fravær.AktivitetFravær
 import no.nav.k9.søknad.felles.fravær.SøknadÅrsak
 import no.nav.k9.søknad.felles.type.Organisasjonsnummer
 import no.nav.k9brukerdialogapi.somJson
@@ -82,9 +81,8 @@ class UtbetalingsperiodeTest {
             antallTimerPlanlagt = Duration.ofHours(7),
             årsak = ORDINÆRT_FRAVÆR
         )
-        val faktiskFraværPeriode = utbetalingsperiode.somFraværPeriode(
+        val faktiskFraværPeriode = utbetalingsperiode.somFraværPeriodeForArbeidstaker(
             SøknadÅrsak.ARBEIDSGIVER_KONKURS,
-            listOf(AktivitetFravær.ARBEIDSTAKER),
             Organisasjonsnummer.of("825905162")
         ).somJson()
         val forventetFraværPeriode = """


### PR DESCRIPTION
Flytter ut felles klasser som Bekreftelser, Bosted, Opphold til fellesdomene.
Refaktorerer Utbetalingsperiode til å støtte arbeidstaker, selvstending næringsdrivende og frilans. 