### PR TITLE
Datastruktur for omsorgsdager melding

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Arbeidssituasjon.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Arbeidssituasjon.kt
@@ -1,10 +1,8 @@
 package no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene
 
-import com.fasterxml.jackson.annotation.JsonAlias
-
 enum class Arbeidssituasjon {
-    @JsonAlias("annen") ANNEN,
-    @JsonAlias("frilanser") FRILANSER,
-    @JsonAlias("arbeidstaker") ARBEIDSTAKER,
-    @JsonAlias("selvstendigNæringsdrivende") SELVSTENDIG_NÆRINGSDRIVENDE
+    ANNEN,
+    FRILANSER,
+    ARBEIDSTAKER,
+    SELVSTENDIG_NÆRINGSDRIVENDE
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Barn.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Barn.kt
@@ -13,6 +13,12 @@ class Barn(
     private val aleneOmOmsorgen: Boolean? = null,
     private val utvidetRett: Boolean? = null
 ) {
+    companion object {
+        internal fun List<Barn>.valider(felt: String) = flatMapIndexed { index: Int, barn: Barn ->
+            barn.valider("$felt[$index]")
+        }
+    }
+
     fun valider(felt: String) = mutableListOf<String>().apply {
         validerIdentifikator(identitetsnummer, "$felt.identitetsnummer")
         krever(navn.isNotBlank(), "$felt.navn kan ikke være tomt eller blank.")
@@ -21,7 +27,7 @@ class Barn(
     }
 
     fun manglerIdentitetsnummer() = identitetsnummer.isNullOrBlank()
-    fun oppdaterIdentitetsnummerMed(identitetsnummer: String){
+    fun oppdaterIdentitetsnummerMed(identitetsnummer: String) {
         require(manglerIdentitetsnummer()) { "Kan kun oppdatere identitetsnummer på barn som mangler." }
         this.identitetsnummer = identitetsnummer
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Koronaoverføre.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Koronaoverføre.kt
@@ -1,6 +1,5 @@
 package no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene
 
-import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonFormat
 import no.nav.k9brukerdialogapi.general.krever
 import java.time.LocalDate
@@ -23,8 +22,8 @@ class Koronaoverføre(
 }
 
 class KoronaStengingsperiode(
-    @JsonAlias("fom") @JsonFormat(pattern = "yyyy-MM-dd") val fraOgMed: LocalDate,
-    @JsonAlias("tom") @JsonFormat(pattern = "yyyy-MM-dd") val tilOgMed: LocalDate
+    @JsonFormat(pattern = "yyyy-MM-dd") val fraOgMed: LocalDate,
+    @JsonFormat(pattern = "yyyy-MM-dd") val tilOgMed: LocalDate
 ) {
     override fun toString(): String = "KoronaStengingsperiode(fraOgMed=$fraOgMed, tilOgMed=$tilOgMed)"
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Melding.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Melding.kt
@@ -1,0 +1,37 @@
+package no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene
+
+import no.nav.helse.dusseldorf.ktor.core.Throwblem
+import no.nav.k9brukerdialogapi.general.ValidationProblemDetails
+import no.nav.k9brukerdialogapi.general.krever
+import no.nav.k9brukerdialogapi.general.kreverIkkeNull
+import no.nav.k9brukerdialogapi.general.validerIdentifikator
+import no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene.Barn.Companion.valider
+import java.util.*
+
+class Melding(
+    private val søknadId: String = UUID.randomUUID().toString(),
+    private val id: String,
+    private val språk: String,
+    private val barn: List<Barn>,
+    private val mottakerFnr: String,
+    private val mottakerNavn: String,
+    private val harAleneomsorg: Boolean? = null,
+    private val harUtvidetRett: Boolean? = null,
+    private val arbeidssituasjon: List<Arbeidssituasjon>,
+    private val harForståttRettigheterOgPlikter: Boolean,
+    private val harBekreftetOpplysninger: Boolean
+) {
+    fun valider() = mutableListOf<String>().apply {
+        validerIdentifikator(mottakerFnr, "mottakerFnr")
+        krever(barn.isNotEmpty(), "barn kan ikke være en tom liste.")
+        krever(harBekreftetOpplysninger, "harBekreftetOpplysninger må være true.")
+        krever(mottakerNavn.isNotBlank(), "mottakerNavn kan ikke være tomt eller blankt.")
+        krever(arbeidssituasjon.isNotEmpty(), "arbeidssituasjon kan ikke være en tom liste.")
+        krever(harForståttRettigheterOgPlikter, "harForståttRettigheterOgPlikter må være true.")
+        kreverIkkeNull(harAleneomsorg, "harAleneomsorg kan ikke være null. Må være true/false.")
+        kreverIkkeNull(harUtvidetRett, "harUtvidetRett kan ikke være null. Må være true/false.")
+
+        addAll(barn.valider("barn"))
+        if (isNotEmpty()) throw Throwblem(ValidationProblemDetails(this))
+    }
+}

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Melding.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Melding.kt
@@ -6,6 +6,7 @@ import no.nav.k9brukerdialogapi.general.krever
 import no.nav.k9brukerdialogapi.general.kreverIkkeNull
 import no.nav.k9brukerdialogapi.general.validerIdentifikator
 import no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene.Barn.Companion.valider
+import no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene.Meldingstype.*
 import java.util.*
 
 class Melding(
@@ -17,21 +18,53 @@ class Melding(
     private val mottakerNavn: String,
     private val harAleneomsorg: Boolean? = null,
     private val harUtvidetRett: Boolean? = null,
+    private val erYrkesaktiv: Boolean? = null,
+    private val arbeiderINorge: Boolean? = null,
     private val arbeidssituasjon: List<Arbeidssituasjon>,
+    private val antallDagerBruktIÅr: Int? = null,
+    private val type: Meldingstype,
+    private val korona: Koronaoverføre? = null,
+    private val overføring: Overføre? = null,
+    private val fordeling: Fordele? = null,
     private val harForståttRettigheterOgPlikter: Boolean,
     private val harBekreftetOpplysninger: Boolean
 ) {
     fun valider() = mutableListOf<String>().apply {
         validerIdentifikator(mottakerFnr, "mottakerFnr")
         krever(barn.isNotEmpty(), "barn kan ikke være en tom liste.")
-        krever(harBekreftetOpplysninger, "harBekreftetOpplysninger må være true.")
         krever(mottakerNavn.isNotBlank(), "mottakerNavn kan ikke være tomt eller blankt.")
         krever(arbeidssituasjon.isNotEmpty(), "arbeidssituasjon kan ikke være en tom liste.")
+        krever(harBekreftetOpplysninger, "harBekreftetOpplysninger må være true.")
         krever(harForståttRettigheterOgPlikter, "harForståttRettigheterOgPlikter må være true.")
-        kreverIkkeNull(harAleneomsorg, "harAleneomsorg kan ikke være null. Må være true/false.")
-        kreverIkkeNull(harUtvidetRett, "harUtvidetRett kan ikke være null. Må være true/false.")
 
         addAll(barn.valider("barn"))
+        validerKreverIkkeNull()
+        validerType()
+
         if (isNotEmpty()) throw Throwblem(ValidationProblemDetails(this))
+    }
+
+    private fun MutableList<String>.validerKreverIkkeNull() {
+        kreverIkkeNull(erYrkesaktiv, "erYrkesaktiv kan ikke være null. Må være true/false.")
+        kreverIkkeNull(arbeiderINorge, "arbeiderINorge kan ikke være null. Må være true/false.")
+        kreverIkkeNull(harAleneomsorg, "harAleneomsorg kan ikke være null. Må være true/false.")
+        kreverIkkeNull(harUtvidetRett, "harUtvidetRett kan ikke være null. Må være true/false.")
+    }
+
+    private fun MutableList<String>.validerType() {
+        when (type) {
+            OVERFORING -> {
+                kreverIkkeNull(overføring, "Ved type=OVERFORING kan ikke 'overføring' være null.")
+                overføring?.valider("overføring")
+            }
+            FORDELING -> {
+                kreverIkkeNull(fordeling, "Ved type=FORDELING kan ikke 'fordeling' være null.")
+                fordeling?.valider("fordeling")
+            }
+            KORONA -> {
+                kreverIkkeNull(korona, "Ved type=KORONA kan ikke 'korona' være null.")
+                korona?.valider("korona")
+            }
+        }
     }
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Meldingstype.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Meldingstype.kt
@@ -1,9 +1,7 @@
 package no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene
 
-import com.fasterxml.jackson.annotation.JsonAlias
-
 enum class Meldingstype {
-    @JsonAlias("fordeling") FORDELING,
-    @JsonAlias("overføring") OVERFORING,
-    @JsonAlias("koronaoverføring") KORONA,
+    FORDELING,
+    OVERFORING,
+    KORONA
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Mottaker.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Mottaker.kt
@@ -1,9 +1,7 @@
 package no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene
 
-import com.fasterxml.jackson.annotation.JsonAlias
-
 enum class Mottaker() {
-    @JsonAlias("samboer") SAMBOER,
-    @JsonAlias("ektefelle") EKTEFELLE,
-    @JsonAlias("samværsforelder") SAMVÆRSFORELDER
+    SAMBOER,
+    EKTEFELLE,
+    SAMVÆRSFORELDER
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Overføre.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/Overføre.kt
@@ -17,5 +17,4 @@ class Overføre(
         krever(mottakerType in gyldigeMottakere, "$felt.mottakerType må være en av $gyldigeMottakere.")
         krever(antallDagerSomSkalOverføres in gyldigDagerRange, "$felt.antallDagerSomSkalOverføres må være innenfor range $gyldigDagerRange.")
     }
-
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/TestUtils.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/TestUtils.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertContains
 class TestUtils {
     companion object {
 
-        internal fun MutableList<String>.verifiserFeil(antallFeil: Int, valideringsfeil: List<String> = listOf()) {
+        internal fun List<String>.verifiserFeil(antallFeil: Int, valideringsfeil: List<String> = listOf()) {
             assertEquals(antallFeil, this.size)
 
             valideringsfeil.forEach {
@@ -22,7 +22,7 @@ class TestUtils {
             }
         }
 
-        internal fun MutableList<String>.verifiserIngenFeil() {
+        internal fun List<String>.verifiserIngenFeil() {
             assertTrue(this.isEmpty())
         }
 

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/FordeleTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/FordeleTest.kt
@@ -27,5 +27,4 @@ class FordeleTest {
         val komplettFordele = fordele.somKomplettFordele()
         assertEquals(komplettFordele.samværsavtaleVedleggId.first(), vedleggId)
     }
-
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/MeldingTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/MeldingTest.kt
@@ -1,0 +1,187 @@
+package no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene
+
+import no.nav.helse.dusseldorf.ktor.core.Throwblem
+import no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene.Arbeidssituasjon.ARBEIDSTAKER
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class MeldingTest {
+
+    @Test
+    fun `Gyldig melding gir ingen feil`(){
+        Melding(
+            id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+            språk = "nb",
+            mottakerFnr = "26104500284",
+            mottakerNavn = "Navnesen",
+            barn = listOf(Barn(
+                identitetsnummer = "02119970078",
+                fødselsdato = LocalDate.now(),
+                navn = "Navnesen",
+                aleneOmOmsorgen = true,
+                utvidetRett = true
+            )),
+            harUtvidetRett = true,
+            harAleneomsorg = true,
+            arbeidssituasjon = listOf(ARBEIDSTAKER),
+            harForståttRettigheterOgPlikter = true,
+            harBekreftetOpplysninger = true
+        ).valider()
+    }
+
+    @Test
+    fun `Melding hvor harBekreftetOpplysninger og harForståttRettigheterOgPlikter er false gir feil`(){
+        assertThrows<Throwblem> {
+            Melding(
+                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                språk = "nb",
+                mottakerFnr = "26104500284",
+                mottakerNavn = "Navnesen",
+                barn = listOf(Barn(
+                    identitetsnummer = "02119970078",
+                    fødselsdato = LocalDate.now(),
+                    navn = "Navnesen",
+                    aleneOmOmsorgen = true,
+                    utvidetRett = true
+                )),
+                harUtvidetRett = true,
+                harAleneomsorg = true,
+                arbeidssituasjon = listOf(ARBEIDSTAKER),
+                harBekreftetOpplysninger = false,
+                harForståttRettigheterOgPlikter = false
+            ).valider()
+        }.also {
+            assertTrue { it.message.toString().contains("harForståttRettigheterOgPlikter må være true.") }
+            assertTrue { it.message.toString().contains("harBekreftetOpplysninger må være true.") }
+        }
+    }
+
+    @Test
+    fun `Melding hvor mottakerFnr og navn er ugyldig skal gi feil`(){
+        assertThrows<Throwblem> {
+            Melding(
+                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                språk = "nb",
+                mottakerFnr = "123abc",
+                mottakerNavn = "",
+                barn = listOf(Barn(
+                    identitetsnummer = "02119970078",
+                    fødselsdato = LocalDate.now(),
+                    navn = "Navnesen",
+                    aleneOmOmsorgen = true,
+                    utvidetRett = true
+                )),
+                harUtvidetRett = true,
+                harAleneomsorg = true,
+                arbeidssituasjon = listOf(ARBEIDSTAKER),
+                harBekreftetOpplysninger = true,
+                harForståttRettigheterOgPlikter = true
+            ).valider()
+        }.also {
+            assertTrue { it.message.toString().contains("mottakerFnr er ikke gyldig identifikator, '123abc*****'. Forventet at personidentifikator kun var siffer, men var 123abc****** (6)") }
+            assertTrue { it.message.toString().contains("mottakerNavn kan ikke være tomt eller blankt.") }
+        }
+    }
+
+    @Test
+    fun `Melding hvor arbeidssituasjon er tom liste skal gi feil`(){
+        assertThrows<Throwblem> {
+            Melding(
+                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                språk = "nb",
+                mottakerFnr = "26104500284",
+                mottakerNavn = "Navnesen",
+                barn = listOf(Barn(
+                    identitetsnummer = "02119970078",
+                    fødselsdato = LocalDate.now(),
+                    navn = "Navnesen",
+                    aleneOmOmsorgen = true,
+                    utvidetRett = true
+                )),
+                arbeidssituasjon = listOf(),
+                harUtvidetRett = true,
+                harAleneomsorg = true,
+                harBekreftetOpplysninger = true,
+                harForståttRettigheterOgPlikter = true
+            ).valider()
+        }.also {
+            assertTrue { it.message.toString().contains("arbeidssituasjon kan ikke være en tom liste.") }
+        }
+    }
+
+    @Test
+    fun `Melding hvor barn er tom liste skal gi feil`(){
+        assertThrows<Throwblem> {
+            Melding(
+                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                språk = "nb",
+                mottakerFnr = "26104500284",
+                mottakerNavn = "Navnesen",
+                barn = listOf(),
+                arbeidssituasjon = listOf(ARBEIDSTAKER),
+                harUtvidetRett = true,
+                harAleneomsorg = true,
+                harBekreftetOpplysninger = true,
+                harForståttRettigheterOgPlikter = true
+            ).valider()
+        }.also {
+            assertTrue { it.message.toString().contains("barn kan ikke være en tom liste.") }
+        }
+    }
+
+    @Test
+    fun `Melding hvor barn er ugyldig skal gi feil`(){
+        assertThrows<Throwblem> {
+            Melding(
+                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                språk = "nb",
+                mottakerFnr = "26104500284",
+                mottakerNavn = "Navnesen",
+                barn = listOf(Barn(
+                    identitetsnummer = "26104500284",
+                    fødselsdato = LocalDate.now(),
+                    navn = "Navnesen",
+                    aleneOmOmsorgen = null,
+                    utvidetRett = null
+                )),
+                harUtvidetRett = true,
+                harAleneomsorg = true,
+                arbeidssituasjon = listOf(ARBEIDSTAKER),
+                harBekreftetOpplysninger = true,
+                harForståttRettigheterOgPlikter = true
+            ).valider()
+        }.also {
+            assertTrue { it.message.toString().contains("barn[0].aleneOmOmsorgen kan ikke være null. Må være true/false.") }
+            assertTrue { it.message.toString().contains("barn[0].utvidetRett kan ikke være null. Må være true/false.") }
+        }
+    }
+
+    @Test
+    fun `Melding hvor harAleneomsorg og harUtvidetRett er null skal gi feil`(){
+        assertThrows<Throwblem> {
+            Melding(
+                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                språk = "nb",
+                mottakerFnr = "26104500284",
+                mottakerNavn = "Navnesen",
+                barn = listOf(Barn(
+                    identitetsnummer = "02119970078",
+                    fødselsdato = LocalDate.now(),
+                    navn = "Navnesen",
+                    aleneOmOmsorgen = true,
+                    utvidetRett = true
+                )),
+                harUtvidetRett = null,
+                harAleneomsorg = null,
+                arbeidssituasjon = listOf(ARBEIDSTAKER),
+                harBekreftetOpplysninger = true,
+                harForståttRettigheterOgPlikter = true
+            ).valider()
+        }.also {
+            assertTrue { it.message.toString().contains("harUtvidetRett kan ikke være null. Må være true/false.") }
+            assertTrue { it.message.toString().contains("harAleneomsorg kan ikke være null. Må være true/false.") }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/MeldingTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/MeldingTest.kt
@@ -25,7 +25,11 @@ class MeldingTest {
             )),
             harUtvidetRett = true,
             harAleneomsorg = true,
+            erYrkesaktiv = true,
+            arbeiderINorge = true,
             arbeidssituasjon = listOf(ARBEIDSTAKER),
+            type = Meldingstype.KORONA,
+            korona = Koronaoverføre(4),
             harForståttRettigheterOgPlikter = true,
             harBekreftetOpplysninger = true
         ).valider()
@@ -48,7 +52,11 @@ class MeldingTest {
                 )),
                 harUtvidetRett = true,
                 harAleneomsorg = true,
+                erYrkesaktiv = true,
+                arbeiderINorge = true,
                 arbeidssituasjon = listOf(ARBEIDSTAKER),
+                type = Meldingstype.KORONA,
+                korona = Koronaoverføre(4),
                 harBekreftetOpplysninger = false,
                 harForståttRettigheterOgPlikter = false
             ).valider()
@@ -75,7 +83,11 @@ class MeldingTest {
                 )),
                 harUtvidetRett = true,
                 harAleneomsorg = true,
+                erYrkesaktiv = true,
+                arbeiderINorge = true,
                 arbeidssituasjon = listOf(ARBEIDSTAKER),
+                type = Meldingstype.KORONA,
+                korona = Koronaoverføre(4),
                 harBekreftetOpplysninger = true,
                 harForståttRettigheterOgPlikter = true
             ).valider()
@@ -86,47 +98,26 @@ class MeldingTest {
     }
 
     @Test
-    fun `Melding hvor arbeidssituasjon er tom liste skal gi feil`(){
+    fun `Melding hvor arbeidssituasjon og barn er tom liste skal gi feil`(){
         assertThrows<Throwblem> {
             Melding(
                 id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
                 språk = "nb",
                 mottakerFnr = "26104500284",
                 mottakerNavn = "Navnesen",
-                barn = listOf(Barn(
-                    identitetsnummer = "02119970078",
-                    fødselsdato = LocalDate.now(),
-                    navn = "Navnesen",
-                    aleneOmOmsorgen = true,
-                    utvidetRett = true
-                )),
                 arbeidssituasjon = listOf(),
+                barn = listOf(),
                 harUtvidetRett = true,
                 harAleneomsorg = true,
+                erYrkesaktiv = true,
+                arbeiderINorge = true,
+                type = Meldingstype.KORONA,
+                korona = Koronaoverføre(4),
                 harBekreftetOpplysninger = true,
                 harForståttRettigheterOgPlikter = true
             ).valider()
         }.also {
             assertTrue { it.message.toString().contains("arbeidssituasjon kan ikke være en tom liste.") }
-        }
-    }
-
-    @Test
-    fun `Melding hvor barn er tom liste skal gi feil`(){
-        assertThrows<Throwblem> {
-            Melding(
-                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
-                språk = "nb",
-                mottakerFnr = "26104500284",
-                mottakerNavn = "Navnesen",
-                barn = listOf(),
-                arbeidssituasjon = listOf(ARBEIDSTAKER),
-                harUtvidetRett = true,
-                harAleneomsorg = true,
-                harBekreftetOpplysninger = true,
-                harForståttRettigheterOgPlikter = true
-            ).valider()
-        }.also {
             assertTrue { it.message.toString().contains("barn kan ikke være en tom liste.") }
         }
     }
@@ -148,7 +139,11 @@ class MeldingTest {
                 )),
                 harUtvidetRett = true,
                 harAleneomsorg = true,
+                erYrkesaktiv = true,
+                arbeiderINorge = true,
                 arbeidssituasjon = listOf(ARBEIDSTAKER),
+                type = Meldingstype.KORONA,
+                korona = Koronaoverføre(4),
                 harBekreftetOpplysninger = true,
                 harForståttRettigheterOgPlikter = true
             ).valider()
@@ -159,7 +154,7 @@ class MeldingTest {
     }
 
     @Test
-    fun `Melding hvor harAleneomsorg og harUtvidetRett er null skal gi feil`(){
+    fun `Melding hvor harAleneomsorg, harUtvidetRett, arbeiderINorge og erYrkesaktiv er null skal gi feil`(){
         assertThrows<Throwblem> {
             Melding(
                 id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
@@ -175,13 +170,51 @@ class MeldingTest {
                 )),
                 harUtvidetRett = null,
                 harAleneomsorg = null,
+                erYrkesaktiv = null,
+                arbeiderINorge = null,
                 arbeidssituasjon = listOf(ARBEIDSTAKER),
+                type = Meldingstype.KORONA,
+                korona = Koronaoverføre(4),
                 harBekreftetOpplysninger = true,
                 harForståttRettigheterOgPlikter = true
             ).valider()
         }.also {
             assertTrue { it.message.toString().contains("harUtvidetRett kan ikke være null. Må være true/false.") }
             assertTrue { it.message.toString().contains("harAleneomsorg kan ikke være null. Må være true/false.") }
+            assertTrue { it.message.toString().contains("arbeiderINorge kan ikke være null. Må være true/false.") }
+            assertTrue { it.message.toString().contains("erYrkesaktiv kan ikke være null. Må være true/false.") }
+        }
+    }
+
+    @Test
+    fun `Melding hvor type=KORONA men korona er null skal gi feil`() {
+        assertThrows<Throwblem> {
+            Melding(
+                id = "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                språk = "nb",
+                mottakerFnr = "26104500284",
+                mottakerNavn = "Navnesen",
+                barn = listOf(
+                    Barn(
+                        identitetsnummer = "02119970078",
+                        fødselsdato = LocalDate.now(),
+                        navn = "Navnesen",
+                        aleneOmOmsorgen = true,
+                        utvidetRett = true
+                    )
+                ),
+                harUtvidetRett = true,
+                harAleneomsorg = true,
+                erYrkesaktiv = true,
+                arbeiderINorge = true,
+                arbeidssituasjon = listOf(ARBEIDSTAKER),
+                type = Meldingstype.KORONA,
+                korona = null,
+                harForståttRettigheterOgPlikter = true,
+                harBekreftetOpplysninger = true
+            ).valider()
+        }.also {
+            assertTrue { it.message.toString().contains("Ved type=KORONA kan ikke 'korona' være null.") }
         }
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/OmsorgsdagerMeldingBarnTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/domene/OmsorgsdagerMeldingBarnTest.kt
@@ -2,6 +2,7 @@ package no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene
 
 import no.nav.helse.TestUtils.Companion.verifiserFeil
 import no.nav.helse.TestUtils.Companion.verifiserIngenFeil
+import no.nav.k9brukerdialogapi.ytelse.omsorgsdagermelding.domene.Barn.Companion.valider
 import java.time.LocalDate
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -76,5 +77,30 @@ class BarnTest {
             aleneOmOmsorgen = true,
             utvidetRett = null
         ).valider("barn").verifiserFeil(1, listOf("barn.utvidetRett kan ikke være null. Må være true/false."))
+    }
+
+    @Test
+    fun `Liste med barn med utvidetRett=null gir feil`(){
+        listOf(
+            Barn(
+                identitetsnummer = "02119970078",
+                fødselsdato = LocalDate.parse("2022-01-01"),
+                navn = "Ola",
+                aleneOmOmsorgen = true,
+                utvidetRett = null
+            ),
+            Barn(
+                identitetsnummer = "02119970078",
+                fødselsdato = LocalDate.parse("2022-01-01"),
+                navn = "Ola",
+                aleneOmOmsorgen = true,
+                utvidetRett = null
+            )
+        ).valider("barn").verifiserFeil(2,
+            listOf(
+                "barn[0].utvidetRett kan ikke være null. Må være true/false.",
+                "barn[1].utvidetRett kan ikke være null. Må være true/false."
+            )
+        )
     }
 }


### PR DESCRIPTION
Legger til datastruktur for melding med tilhørende enhetstester. 
Fjerner jsonalias som ikke er nødvendig. Frontend skal send riktig verdi ved migrering. 
