### PR TITLE
Cacher innsendinger i 1 minutt.

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/App.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/App.kt
@@ -36,6 +36,7 @@ import no.nav.helse.dusseldorf.ktor.metrics.MetricsRoute
 import no.nav.helse.dusseldorf.ktor.metrics.init
 import no.nav.helse.dusseldorf.oauth2.client.CachedAccessTokenClient
 import no.nav.k9brukerdialogapi.general.AccessTokenClientResolver
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.KafkaProducer
 import no.nav.k9brukerdialogapi.mellomlagring.K9BrukerdialogCacheGateway
@@ -173,7 +174,9 @@ fun Application.k9BrukerdialogApi() {
             k9BrukerdialogCacheGateway = k9BrukerdialogCacheGateway
         )
 
-        val innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService)
+        val innsendingCache = InnsendingCache(expireMinutes = configuration.getInnSendingCacheExpiryMinutes())
+
+        val innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService, innsendingCache)
 
         environment!!.monitor.subscribe(ApplicationStopping) {
             logger.info("Stopper Kafka Producer.")

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/App.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/App.kt
@@ -176,7 +176,7 @@ fun Application.k9BrukerdialogApi() {
 
         val innsendingCache = InnsendingCache(expireMinutes = configuration.getInnSendingCacheExpiryMinutes())
 
-        val innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService, innsendingCache)
+        val innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService)
 
         environment!!.monitor.subscribe(ApplicationStopping) {
             logger.info("Stopper Kafka Producer.")
@@ -188,7 +188,8 @@ fun Application.k9BrukerdialogApi() {
             ytelseRoutes(
                 idTokenProvider = idTokenProvider,
                 barnService = barnService,
-                innsendingService = innsendingService
+                innsendingService = innsendingService,
+                innsendingCache = innsendingCache
             )
 
             oppslagRoutes(

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/Configuration.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/Configuration.kt
@@ -73,4 +73,8 @@ data class Configuration(val config : ApplicationConfig) {
             .maximumSize(maxSize)
             .build()
     }
+
+    fun getInnSendingCacheExpiryMinutes(): Long {
+        return config.getRequiredString("nav.cache.innsending.expiry_in_minutes", secret = false).toLong()
+    }
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCache.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCache.kt
@@ -14,7 +14,7 @@ class InnsendingCache(expireMinutes: Long) {
     private val cache: Cache<String, String> = Caffeine.newBuilder()
         .maximumSize(1000)
         .expireAfterWrite(Duration.ofMinutes(expireMinutes))
-        .evictionListener<String, String?> { key, value, cause -> logger.info("Evicting expired key: {}", key) }
+        .evictionListener<String, String> { _, _, _ -> logger.info("Tømmer cache for ugått innsending.") }
         .build()
 
     companion object {

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCache.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCache.kt
@@ -1,0 +1,44 @@
+package no.nav.k9brukerdialogapi.innsending
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import no.nav.helse.dusseldorf.ktor.core.DefaultProblemDetails
+import no.nav.helse.dusseldorf.ktor.core.Throwblem
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.time.Duration
+
+class InnsendingCache(expireMinutes: Long) {
+
+    private val cache: Cache<String, String> = Caffeine.newBuilder()
+        .maximumSize(1000)
+        .expireAfterWrite(Duration.ofMinutes(expireMinutes))
+        .evictionListener<String, String?> { key, value, cause -> logger.info("Evicting expired key: {}", key) }
+        .build()
+
+    companion object {
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+
+    @kotlin.jvm.Throws(Throwblem::class)
+    fun put(key: String) {
+        if (duplikatEksisterer(key)) {
+            throw Throwblem(DuplikatInnsendingProblem())
+        }
+        cache.put(key, "") // verdi er ikke relevant. Vi er kun interessert i key.
+    }
+
+    private fun duplikatEksisterer(key: String): Boolean = when (cache.getIfPresent(key)) {
+        null -> false
+        else -> true
+    }
+}
+
+class DuplikatInnsendingProblem: DefaultProblemDetails(
+    title = "Duplikat innsending",
+    type = URI("/problem-details/duplikat-innsendin"),
+    status = 400,
+    detail = "Det ble funnet en eksisterende innsending på søker med samme ytelse.",
+    instance = URI("")
+)

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingService.kt
@@ -26,15 +26,11 @@ import org.slf4j.LoggerFactory
 class InnsendingService(
     private val søkerService: SøkerService,
     private val kafkaProdusent: KafkaProducer,
-    private val vedleggService: VedleggService,
-    private val innsendingCache: InnsendingCache
+    private val vedleggService: VedleggService
 ) {
 
     internal suspend fun registrer(innsending: Innsending, callId: CallId, idToken: IdToken, metadata: Metadata) {
         val søker = søkerService.hentSøker(idToken, callId)
-        val cacheKey = "${søker.somK9Søker().personIdent.verdi}_${innsending.ytelse()}"
-
-        innsendingCache.put(cacheKey)
 
         logger.info(formaterStatuslogging(innsending.ytelse(), innsending.søknadId(), "registreres."))
 

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/YtelseRoutes.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/YtelseRoutes.kt
@@ -2,6 +2,7 @@ package no.nav.k9brukerdialogapi.ytelse
 
 import io.ktor.server.routing.Route
 import no.nav.helse.dusseldorf.ktor.auth.IdTokenProvider
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
 import no.nav.k9brukerdialogapi.ytelse.ettersending.ettersendingApis
@@ -16,14 +17,15 @@ import no.nav.k9brukerdialogapi.ytelse.pleiepengerlivetssluttfase.pleiepengerLiv
 fun Route.ytelseRoutes(
     idTokenProvider: IdTokenProvider,
     innsendingService: InnsendingService,
-    barnService: BarnService
+    barnService: BarnService,
+    innsendingCache: InnsendingCache
 ){
-    pleiepengerLivetsSluttfaseApi(innsendingService, idTokenProvider)
-    omsorgspengerUtbetalingArbeidstakerApi(innsendingService, idTokenProvider)
-    ettersendingApis(innsendingService, idTokenProvider)
-    omsorgspengerUtvidetRettApis(innsendingService, barnService, idTokenProvider)
-    omsorgspengerUtbetalingSnfApis(innsendingService, barnService, idTokenProvider)
-    omsorgspengerMidlertidigAleneApis(innsendingService, barnService, idTokenProvider)
-    omsorgsdagerMeldingApi(innsendingService, barnService, idTokenProvider)
-    omsorgsdagerAleneomsorgApis(innsendingService, barnService, idTokenProvider)
+    pleiepengerLivetsSluttfaseApi(innsendingService, innsendingCache, idTokenProvider)
+    omsorgspengerUtbetalingArbeidstakerApi(innsendingService, innsendingCache, idTokenProvider)
+    ettersendingApis(innsendingService, innsendingCache, idTokenProvider)
+    omsorgspengerUtvidetRettApis(innsendingService, barnService, innsendingCache, idTokenProvider)
+    omsorgspengerUtbetalingSnfApis(innsendingService, barnService, innsendingCache, idTokenProvider)
+    omsorgspengerMidlertidigAleneApis(innsendingService, barnService, innsendingCache, idTokenProvider)
+    omsorgsdagerMeldingApi(innsendingService, barnService, innsendingCache, idTokenProvider)
+    omsorgsdagerAleneomsorgApis(innsendingService, barnService, innsendingCache, idTokenProvider)
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingApis.kt
@@ -10,6 +10,7 @@ import no.nav.k9brukerdialogapi.ETTERSENDING_URL
 import no.nav.k9brukerdialogapi.INNSENDING_URL
 import no.nav.k9brukerdialogapi.general.formaterStatuslogging
 import no.nav.k9brukerdialogapi.general.getCallId
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.ytelse.ettersending.domene.Ettersendelse
@@ -21,14 +22,20 @@ private val logger: Logger = LoggerFactory.getLogger("ytelse.ettersending.etters
 
 fun Route.ettersendingApis(
     innsendingService: InnsendingService,
+    innsendingCache: InnsendingCache,
     idTokenProvider: IdTokenProvider,
 ){
     route(ETTERSENDING_URL){
         post(INNSENDING_URL){
             val ettersendelse =  call.receive<Ettersendelse>()
+            val idToken = idTokenProvider.getIdToken(call)
+
+            val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${ettersendelse.ytelse()}"
+            innsendingCache.put(cacheKey)
+
             logger.info(formaterStatuslogging(ettersendelse.ytelse(), ettersendelse.søknadId, "mottatt."))
             logger.info("Ettersending for ytelse ${ettersendelse.søknadstype}")
-            innsendingService.registrer(ettersendelse, call.getCallId(),  idTokenProvider.getIdToken(call), call.getMetadata())
+            innsendingService.registrer(ettersendelse, call.getCallId(), idToken, call.getMetadata())
             registrerMottattSøknad(ettersendelse.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgApis.kt
@@ -10,6 +10,7 @@ import no.nav.k9brukerdialogapi.INNSENDING_URL
 import no.nav.k9brukerdialogapi.OMSORGSDAGER_ALENEOMSORG_URL
 import no.nav.k9brukerdialogapi.general.formaterStatuslogging
 import no.nav.k9brukerdialogapi.general.getCallId
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
@@ -23,6 +24,7 @@ private val logger: Logger = LoggerFactory.getLogger("ytelse.omsorgsdageraleneom
 fun Route.omsorgsdagerAleneomsorgApis(
     innsendingService: InnsendingService,
     barnService: BarnService,
+    innsendingCache: InnsendingCache,
     idTokenProvider: IdTokenProvider,
 ){
     route(OMSORGSDAGER_ALENEOMSORG_URL){
@@ -31,6 +33,10 @@ fun Route.omsorgsdagerAleneomsorgApis(
             val callId = call.getCallId()
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
+
+            val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            innsendingCache.put(cacheKey)
+
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
 
             søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneApis.kt
@@ -10,6 +10,7 @@ import no.nav.k9brukerdialogapi.INNSENDING_URL
 import no.nav.k9brukerdialogapi.OMSORGSPENGER_MIDLERTIDIG_ALENE_URL
 import no.nav.k9brukerdialogapi.general.formaterStatuslogging
 import no.nav.k9brukerdialogapi.general.getCallId
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
@@ -23,6 +24,7 @@ private val logger: Logger = LoggerFactory.getLogger("ytelse.omsorgspengermidler
 fun Route.omsorgspengerMidlertidigAleneApis(
     innsendingService: InnsendingService,
     barnService: BarnService,
+    innsendingCache: InnsendingCache,
     idTokenProvider: IdTokenProvider
 ){
     route(OMSORGSPENGER_MIDLERTIDIG_ALENE_URL){
@@ -31,6 +33,9 @@ fun Route.omsorgspengerMidlertidigAleneApis(
             val callId = call.getCallId()
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
+
+            val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
             søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfApis.kt
@@ -10,6 +10,7 @@ import no.nav.k9brukerdialogapi.INNSENDING_URL
 import no.nav.k9brukerdialogapi.OMSORGSPENGER_UTBETALING_SNF_URL
 import no.nav.k9brukerdialogapi.general.formaterStatuslogging
 import no.nav.k9brukerdialogapi.general.getCallId
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
@@ -23,6 +24,7 @@ private val logger: Logger = LoggerFactory.getLogger("ytelse.omsorgspengerutbeta
 fun Route.omsorgspengerUtbetalingSnfApis(
     innsendingService: InnsendingService,
     barnService: BarnService,
+    innsendingCache: InnsendingCache,
     idTokenProvider: IdTokenProvider,
 ) {
     route(OMSORGSPENGER_UTBETALING_SNF_URL){
@@ -31,6 +33,9 @@ fun Route.omsorgspengerUtbetalingSnfApis(
             val callId = call.getCallId()
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
+
+            val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId.id, "mottatt."))
             søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettApis.kt
@@ -10,10 +10,10 @@ import no.nav.k9brukerdialogapi.INNSENDING_URL
 import no.nav.k9brukerdialogapi.OMSORGSPENGER_UTVIDET_RETT_URL
 import no.nav.k9brukerdialogapi.general.formaterStatuslogging
 import no.nav.k9brukerdialogapi.general.getCallId
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
-import no.nav.k9brukerdialogapi.ytelse.Ytelse.OMSORGSPENGER_UTVIDET_RETT
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutvidetrett.domene.OmsorgspengerKroniskSyktBarnSøknad
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
 import org.slf4j.Logger
@@ -24,6 +24,7 @@ private val logger: Logger = LoggerFactory.getLogger("ytelse.omsorgspengerutvide
 fun Route.omsorgspengerUtvidetRettApis(
     innsendingService: InnsendingService,
     barnService: BarnService,
+    innsendingCache: InnsendingCache,
     idTokenProvider: IdTokenProvider
 ){
     route(OMSORGSPENGER_UTVIDET_RETT_URL){
@@ -32,6 +33,9 @@ fun Route.omsorgspengerUtvidetRettApis(
             val callId = call.getCallId()
             val idToken = idTokenProvider.getIdToken(call)
             val metadata = call.getMetadata()
+
+            val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
             søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseApi.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseApi.kt
@@ -10,6 +10,7 @@ import no.nav.k9brukerdialogapi.INNSENDING_URL
 import no.nav.k9brukerdialogapi.PLEIEPENGER_LIVETS_SLUTTFASE_URL
 import no.nav.k9brukerdialogapi.general.formaterStatuslogging
 import no.nav.k9brukerdialogapi.general.getCallId
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.ytelse.pleiepengerlivetssluttfase.domene.PilsSøknad
@@ -19,6 +20,7 @@ import org.slf4j.LoggerFactory
 
 fun Route.pleiepengerLivetsSluttfaseApi(
     innsendingService: InnsendingService,
+    innsendingCache: InnsendingCache,
     idTokenProvider: IdTokenProvider,
 ){
     val logger: Logger = LoggerFactory.getLogger("ytelse.pleiepengerlivetssluttfase.pleiepengerLivetsSluttfaseApi.kt")
@@ -26,8 +28,13 @@ fun Route.pleiepengerLivetsSluttfaseApi(
     route(PLEIEPENGER_LIVETS_SLUTTFASE_URL){
         post(INNSENDING_URL){
             val pilsSøknad = call.receive<PilsSøknad>()
+            val idToken = idTokenProvider.getIdToken(call)
+
+            val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${pilsSøknad.ytelse()}"
+            innsendingCache.put(cacheKey)
+
             logger.info(formaterStatuslogging(pilsSøknad.ytelse(), pilsSøknad.søknadId, "mottatt."))
-            innsendingService.registrer(pilsSøknad, call.getCallId(), idTokenProvider.getIdToken(call), call.getMetadata())
+            innsendingService.registrer(pilsSøknad, call.getCallId(), idToken, call.getMetadata())
             registrerMottattSøknad(pilsSøknad.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -90,5 +90,8 @@ nav {
           max_size = "500"
           max_size = ${?CACHE_MAX_SIZE}
         }
+        innsending{
+          expiry_in_minutes = "1"
+        }
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/InnsendingServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.helse.dusseldorf.ktor.auth.IdToken
 import no.nav.helse.dusseldorf.testsupport.jws.Azure
 import no.nav.k9brukerdialogapi.general.CallId
 import no.nav.k9brukerdialogapi.general.MeldingRegistreringFeiletException
+import no.nav.k9brukerdialogapi.innsending.InnsendingCache
 import no.nav.k9brukerdialogapi.kafka.KafkaProducer
 import no.nav.k9brukerdialogapi.kafka.Metadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
@@ -48,13 +49,16 @@ internal class InnsendingServiceTest{
     lateinit var barnService: BarnService
 
     @RelaxedMockK
+    lateinit var innsendingCache: InnsendingCache
+
+    @RelaxedMockK
     lateinit var vedleggService: VedleggService
     lateinit var innsendingService: InnsendingService
 
     @BeforeEach
     internal fun setUp() {
         MockKAnnotations.init(this)
-        innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService)
+        innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService, innsendingCache)
 
         assertNotNull(kafkaProducer)
         assertNotNull(innsendingService)

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/InnsendingServiceTest.kt
@@ -49,16 +49,13 @@ internal class InnsendingServiceTest{
     lateinit var barnService: BarnService
 
     @RelaxedMockK
-    lateinit var innsendingCache: InnsendingCache
-
-    @RelaxedMockK
     lateinit var vedleggService: VedleggService
     lateinit var innsendingService: InnsendingService
 
     @BeforeEach
     internal fun setUp() {
         MockKAnnotations.init(this)
-        innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService, innsendingCache)
+        innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService)
 
         assertNotNull(kafkaProducer)
         assertNotNull(innsendingService)

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/TestConfiguration.kt
@@ -62,6 +62,7 @@ object TestConfiguration {
         }
 
         map["nav.mellomlagring.søknad_tid_timer"] = "1"
+        map["nav.cache.innsending.expiry_in_minutes"] = "0"
 
         // Kafka
         kafkaEnvironment?.let {

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCacheTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCacheTest.kt
@@ -1,0 +1,27 @@
+package no.nav.k9brukerdialogapi.innsending
+
+import no.nav.helse.dusseldorf.ktor.core.Throwblem
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.net.URI
+import kotlin.test.assertEquals
+
+internal class InnsendingCacheTest {
+
+    @Test
+    fun `gitt en eksisterende nøkkel eksisterer, forvent at det feiler med Throblem`() {
+        val innsendingCache = InnsendingCache(1)
+        innsendingCache.put("123456789_${Ytelse.ETTERSENDING_PLEIEPENGER_LIVETS_SLUTTFASE}")
+
+        val problemDetails = assertThrows<Throwblem> {
+            innsendingCache.put("123456789_${Ytelse.ETTERSENDING_PLEIEPENGER_LIVETS_SLUTTFASE}")
+        }.getProblemDetails()
+
+        assertEquals("Duplikat innsending", problemDetails.title)
+        assertEquals(URI("/problem-details/duplikat-innsendin"), problemDetails.type)
+        assertEquals(400, problemDetails.status)
+        assertEquals("Det ble funnet en eksisterende innsending på søker med samme ytelse.", problemDetails.detail)
+        assertEquals(URI(""), problemDetails.instance)
+    }
+}


### PR DESCRIPTION
Dette er ment å brukes til å håndtere duplikatinnsendinger. 

Nøkkel består søkers ident og ytelse.
Hvis det finnes en eksisterende nøkkel ved innsending vil tjenesten gi en 400 feil. Hvis ikke, vil innsending fungere som normalt.