### PR TITLE
Reduserer caching av innsending til 5 sekunder.

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/App.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/App.kt
@@ -174,7 +174,7 @@ fun Application.k9BrukerdialogApi() {
             k9BrukerdialogCacheGateway = k9BrukerdialogCacheGateway
         )
 
-        val innsendingCache = InnsendingCache(expireMinutes = configuration.getInnSendingCacheExpiryMinutes())
+        val innsendingCache = InnsendingCache(expireSeconds = configuration.getInnSendingCacheExpiryInSeconds())
 
         val innsendingService = InnsendingService(søkerService, kafkaProducer, vedleggService)
 

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/Configuration.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/Configuration.kt
@@ -74,7 +74,7 @@ data class Configuration(val config : ApplicationConfig) {
             .build()
     }
 
-    fun getInnSendingCacheExpiryMinutes(): Long {
-        return config.getRequiredString("nav.cache.innsending.expiry_in_minutes", secret = false).toLong()
+    fun getInnSendingCacheExpiryInSeconds(): Long {
+        return config.getRequiredString("nav.cache.innsending.expiry_in_seconds", secret = false).toLong()
     }
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCache.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingCache.kt
@@ -9,11 +9,11 @@ import org.slf4j.LoggerFactory
 import java.net.URI
 import java.time.Duration
 
-class InnsendingCache(expireMinutes: Long) {
+class InnsendingCache(expireSeconds: Long) {
 
     private val cache: Cache<String, String> = Caffeine.newBuilder()
         .maximumSize(1000)
-        .expireAfterWrite(Duration.ofMinutes(expireMinutes))
+        .expireAfterWrite(Duration.ofSeconds(expireSeconds))
         .evictionListener<String, String> { _, _, _ -> logger.info("Tømmer cache for ugått innsending.") }
         .build()
 

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingApis.kt
@@ -29,14 +29,14 @@ fun Route.ettersendingApis(
         post(INNSENDING_URL){
             val ettersendelse =  call.receive<Ettersendelse>()
             val idToken = idTokenProvider.getIdToken(call)
-
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${ettersendelse.ytelse()}"
-            innsendingCache.put(cacheKey)
+
 
             logger.info(formaterStatuslogging(ettersendelse.ytelse(), ettersendelse.søknadId, "mottatt."))
             logger.info("Ettersending for ytelse ${ettersendelse.søknadstype}")
             innsendingService.registrer(ettersendelse, call.getCallId(), idToken, call.getMetadata())
             registrerMottattSøknad(ettersendelse.ytelse())
+            innsendingCache.put(cacheKey)
             call.respond(HttpStatusCode.Accepted)
         }
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgApis.kt
@@ -33,9 +33,8 @@ fun Route.omsorgsdagerAleneomsorgApis(
             val callId = call.getCallId()
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
-
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
-            innsendingCache.put(cacheKey)
+
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
 
@@ -51,6 +50,7 @@ fun Route.omsorgsdagerAleneomsorgApis(
                 innsendingService.registrer(søknad, callId, idToken, metadata)
             }
             registrerMottattSøknad(søknad.ytelse())
+            innsendingCache.put(cacheKey)
             call.respond(HttpStatusCode.Accepted)
         }
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/OmsorgsdagerMeldingApi.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdagermelding/OmsorgsdagerMeldingApi.kt
@@ -55,9 +55,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.mottaMelding(
     val callId = call.getCallId()
     val metadata = call.getMetadata()
     val idToken = idTokenProvider.getIdToken(call)
-
     val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${melding.ytelse()}"
-    innsendingCache.put(cacheKey)
 
     logger.info(formaterStatuslogging(melding.ytelse(), melding.søknadId, "mottatt."))
 
@@ -65,5 +63,6 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.mottaMelding(
 
     innsendingService.registrer(melding, callId, idToken, metadata)
     registrerMottattSøknad(melding.ytelse())
+    innsendingCache.put(cacheKey)
     call.respond(HttpStatusCode.Accepted)
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneApis.kt
@@ -33,15 +33,14 @@ fun Route.omsorgspengerMidlertidigAleneApis(
             val callId = call.getCallId()
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
-
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
-            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
             søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))
 
             innsendingService.registrer(søknad, callId, idToken, metadata)
             registrerMottattSøknad(søknad.ytelse())
+            innsendingCache.put(cacheKey)
             call.respond(HttpStatusCode.Accepted)
         }
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerApi.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerApi.kt
@@ -29,14 +29,13 @@ fun Route.omsorgspengerUtbetalingArbeidstakerApi(
         post(INNSENDING_URL){
             val søknad =  call.receive<OmsorgspengerutbetalingArbeidstakerSøknad>()
             val idToken = idTokenProvider.getIdToken(call)
-
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
-            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
 
             innsendingService.registrer(søknad, call.getCallId(), idToken, call.getMetadata())
             registrerMottattSøknad(søknad.ytelse())
+            innsendingCache.put(cacheKey)
             call.respond(HttpStatusCode.Accepted)
         }
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfApis.kt
@@ -33,15 +33,14 @@ fun Route.omsorgspengerUtbetalingSnfApis(
             val callId = call.getCallId()
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
-
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
-            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId.id, "mottatt."))
             søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))
 
             innsendingService.registrer(søknad, callId, idToken, metadata)
             registrerMottattSøknad(søknad.ytelse())
+            innsendingCache.put(cacheKey)
             call.respond(HttpStatusCode.Accepted)
         }
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettApis.kt
@@ -33,15 +33,14 @@ fun Route.omsorgspengerUtvidetRettApis(
             val callId = call.getCallId()
             val idToken = idTokenProvider.getIdToken(call)
             val metadata = call.getMetadata()
-
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
-            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
             søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))
 
             innsendingService.registrer(søknad, callId, idToken, metadata)
             registrerMottattSøknad(søknad.ytelse())
+            innsendingCache.put(cacheKey)
             call.respond(HttpStatusCode.Accepted)
         }
     }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseApi.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseApi.kt
@@ -29,13 +29,12 @@ fun Route.pleiepengerLivetsSluttfaseApi(
         post(INNSENDING_URL){
             val pilsSøknad = call.receive<PilsSøknad>()
             val idToken = idTokenProvider.getIdToken(call)
-
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${pilsSøknad.ytelse()}"
-            innsendingCache.put(cacheKey)
 
             logger.info(formaterStatuslogging(pilsSøknad.ytelse(), pilsSøknad.søknadId, "mottatt."))
             innsendingService.registrer(pilsSøknad, call.getCallId(), idToken, call.getMetadata())
             registrerMottattSøknad(pilsSøknad.ytelse())
+            innsendingCache.put(cacheKey)
             call.respond(HttpStatusCode.Accepted)
         }
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -91,7 +91,7 @@ nav {
           max_size = ${?CACHE_MAX_SIZE}
         }
         innsending{
-          expiry_in_minutes = "1"
+          expiry_in_seconds = "5"
         }
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/TestConfiguration.kt
@@ -62,7 +62,7 @@ object TestConfiguration {
         }
 
         map["nav.mellomlagring.søknad_tid_timer"] = "1"
-        map["nav.cache.innsending.expiry_in_minutes"] = "0"
+        map["nav.cache.innsending.expiry_in_seconds"] = "0"
 
         // Kafka
         kafkaEnvironment?.let {


### PR DESCRIPTION
Flytter også caching av innsending nederst, rett før responsen. Dette fjerner uønsket oppførsel der ved feil, så må søker vente med å prøve på nytt fordi innsendingen er cachet.