### PR TITLE
Støtte for styreverv og andre småverv i frilanserdata

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/Frilans.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/Frilans.kt
@@ -13,9 +13,6 @@ data class Frilans(
     val harInntektSomFrilanser: Boolean,
     @JsonFormat(pattern = "yyyy-MM-dd")
     val startdato: LocalDate? = null,
-    @JsonFormat(pattern = "yyyy-MM-dd")
-    val sluttdato: LocalDate? = null,
-    val jobberFortsattSomFrilans: Boolean? = null,
     val arbeidsforhold: Arbeidsforhold? = null,
     val frilansTyper: List<FrilansType>? = null,
     val misterHonorarer: Boolean? = null,
@@ -24,12 +21,8 @@ data class Frilans(
 
     internal fun valider(felt: String) = mutableListOf<String>().apply {
         if(arbeidsforhold != null) addAll(arbeidsforhold.valider("$felt.arbeidsforhold"))
-        if(sluttdato != null && startdato != null){
-            krever(startdato.erFørEllerLik(sluttdato), "$felt.sluttdato kan ikke være etter startdato")
-        }
         if(harInntektSomFrilanser){
-            kreverIkkeNull(startdato, "$felt.startdao kan ikke være null dersom harInntektSomFrilanser=true")
-            kreverIkkeNull(jobberFortsattSomFrilans, "$felt.jobberFortsattSomFrilans kan ikke være null dersom harInntektSomFrilanser=true")
+            kreverIkkeNull(startdato, "$felt.startdato kan ikke være null dersom harInntektSomFrilanser=true")
         }
         if (misterHonorarer != null && misterHonorarer) {
             kreverIkkeNull(misterHonorarerIPerioden, "$felt.misterHonorarerIPerioden kan ikke være null dersom misterHonorarer=true")
@@ -39,22 +32,9 @@ data class Frilans(
     fun k9ArbeidstidInfo(fraOgMed: LocalDate, tilOgMed: LocalDate): ArbeidstidInfo {
         return when{
             (arbeidsforhold == null) -> Arbeidsforhold.k9ArbeidstidInfoMedNullTimer(fraOgMed, tilOgMed)
-            startetOgSluttetISøknadsperioden(fraOgMed, tilOgMed) -> k9ArbeidstidInfoMedStartOgSluttIPerioden(fraOgMed, tilOgMed)
-            sluttetISøknadsperioden(tilOgMed) -> k9ArbeidstidInfoMedSluttIPerioden(fraOgMed, tilOgMed)
             startetISøknadsperioden(fraOgMed) -> k9ArbeidstidInfoMedStartIPerioden(fraOgMed, tilOgMed)
             else -> arbeidsforhold.tilK9ArbeidstidInfo(fraOgMed, tilOgMed)
         }
-    }
-
-    private fun k9ArbeidstidInfoMedStartOgSluttIPerioden(fraOgMed: LocalDate, tilOgMed: LocalDate): ArbeidstidInfo {
-        requireNotNull(arbeidsforhold)
-        requireNotNull(startdato)
-        requireNotNull(sluttdato)
-        val arbeidsforholdFørStart = Arbeidsforhold.k9ArbeidstidInfoMedNullTimer(fraOgMed, startdato.minusDays(1))
-        val arbeidsforholdMedArbeid = arbeidsforhold.tilK9ArbeidstidInfo(startdato, sluttdato)
-        val arbeidsforholdEtterSlutt = Arbeidsforhold.k9ArbeidstidInfoMedNullTimer(sluttdato.plusDays(1), tilOgMed)
-        return slåSammenArbeidstidInfo(arbeidsforholdFørStart, arbeidsforholdMedArbeid, arbeidsforholdEtterSlutt)
-
     }
 
     private fun k9ArbeidstidInfoMedStartIPerioden(fraOgMed: LocalDate, tilOgMed: LocalDate): ArbeidstidInfo {
@@ -64,15 +44,6 @@ data class Frilans(
         val arbeidsforholdEtterStart = arbeidsforhold.tilK9ArbeidstidInfo(startdato, tilOgMed)
         return slåSammenArbeidstidInfo(arbeidsforholdFørStart, arbeidsforholdEtterStart)
     }
-
-    private fun k9ArbeidstidInfoMedSluttIPerioden(fraOgMed: LocalDate, tilOgMed: LocalDate): ArbeidstidInfo {
-        requireNotNull(arbeidsforhold)
-        requireNotNull(sluttdato)
-        val arbeidsforholdFørSlutt = arbeidsforhold.tilK9ArbeidstidInfo(fraOgMed, sluttdato)
-        val arbeidsforholdEtterSlutt = Arbeidsforhold.k9ArbeidstidInfoMedNullTimer(sluttdato.plusDays(1), tilOgMed)
-        return slåSammenArbeidstidInfo(arbeidsforholdFørSlutt, arbeidsforholdEtterSlutt)
-    }
-
 
     private fun slåSammenArbeidstidInfo(vararg arbeidstidInfo: ArbeidstidInfo): ArbeidstidInfo {
         return ArbeidstidInfo().apply {
@@ -87,9 +58,7 @@ data class Frilans(
         }
     }
 
-    private fun sluttetISøknadsperioden(tilOgMed: LocalDate?) = (sluttdato != null && sluttdato.isBefore(tilOgMed))
     private fun startetISøknadsperioden(fraOgMed: LocalDate) = startdato?.isAfter(fraOgMed) ?: false
-    private fun startetOgSluttetISøknadsperioden(fraOgMed: LocalDate, tilOgMed: LocalDate?) = sluttetISøknadsperioden(tilOgMed) && startetISøknadsperioden(fraOgMed)
 }
 
 enum class MisterHonorarerFraVervIPerioden {

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/Frilans.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/Frilans.kt
@@ -16,7 +16,10 @@ data class Frilans(
     @JsonFormat(pattern = "yyyy-MM-dd")
     val sluttdato: LocalDate? = null,
     val jobberFortsattSomFrilans: Boolean? = null,
-    val arbeidsforhold: Arbeidsforhold? = null
+    val arbeidsforhold: Arbeidsforhold? = null,
+    val frilansTyper: List<FrilansType>? = null,
+    val misterHonorarer: Boolean? = null,
+    val misterHonorarerIPerioden: MisterHonorarerFraVervIPerioden? = null
 ) {
 
     internal fun valider(felt: String) = mutableListOf<String>().apply {
@@ -27,6 +30,9 @@ data class Frilans(
         if(harInntektSomFrilanser){
             kreverIkkeNull(startdato, "$felt.startdao kan ikke være null dersom harInntektSomFrilanser=true")
             kreverIkkeNull(jobberFortsattSomFrilans, "$felt.jobberFortsattSomFrilans kan ikke være null dersom harInntektSomFrilanser=true")
+        }
+        if (misterHonorarer != null && misterHonorarer) {
+            kreverIkkeNull(misterHonorarerIPerioden, "$felt.misterHonorarerIPerioden kan ikke være null dersom misterHonorarer=true")
         }
     }
 
@@ -84,4 +90,13 @@ data class Frilans(
     private fun sluttetISøknadsperioden(tilOgMed: LocalDate?) = (sluttdato != null && sluttdato.isBefore(tilOgMed))
     private fun startetISøknadsperioden(fraOgMed: LocalDate) = startdato?.isAfter(fraOgMed) ?: false
     private fun startetOgSluttetISøknadsperioden(fraOgMed: LocalDate, tilOgMed: LocalDate?) = sluttetISøknadsperioden(tilOgMed) && startetISøknadsperioden(fraOgMed)
+}
+
+enum class MisterHonorarerFraVervIPerioden {
+    MISTER_ALLE_HONORARER, MISTER_DELER_AV_HONORARER
+}
+
+enum class FrilansType {
+    FRILANS,
+    STYREVERV
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/k9Format/K9OpptjeningAktivitet.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/k9Format/K9OpptjeningAktivitet.kt
@@ -4,9 +4,7 @@ import no.nav.k9.søknad.felles.opptjening.Frilanser
 import no.nav.k9.søknad.felles.opptjening.OpptjeningAktivitet
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Frilans
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Søknad
-import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.arbeid.DAGER_PER_UKE
 
-fun Double.tilTimerPerDag() = this.div(DAGER_PER_UKE)
 
 internal fun Søknad.byggK9OpptjeningAktivitet(): OpptjeningAktivitet {
     val opptjeningAktivitet = OpptjeningAktivitet()
@@ -22,6 +20,5 @@ internal fun Søknad.byggK9OpptjeningAktivitet(): OpptjeningAktivitet {
 internal fun Frilans.tilK9Frilanser(): Frilanser {
     val frilanser = Frilanser()
     frilanser.medStartdato(startdato)
-    sluttdato?.let { frilanser.medSluttdato(it) }
     return frilanser
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/SøknadUtils.kt
@@ -233,7 +233,6 @@ class SøknadUtils {
                 )
             ),
             frilans = Frilans(
-                jobberFortsattSomFrilans = true,
                 harInntektSomFrilanser = true,
                 startdato = LocalDate.parse("2018-01-01"),
                 frilansTyper = listOf(FrilansType.FRILANS, FrilansType.STYREVERV),

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/SøknadUtils.kt
@@ -16,7 +16,9 @@ import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Enkeltd
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Ferieuttak
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.FerieuttakIPerioden
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Frilans
+import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.FrilansType
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Medlemskap
+import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.MisterHonorarerFraVervIPerioden
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Nattevåk
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Omsorgstilbud
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.OmsorgstilbudSvarFortid
@@ -234,6 +236,9 @@ class SøknadUtils {
                 jobberFortsattSomFrilans = true,
                 harInntektSomFrilanser = true,
                 startdato = LocalDate.parse("2018-01-01"),
+                frilansTyper = listOf(FrilansType.FRILANS, FrilansType.STYREVERV),
+                misterHonorarer = true,
+                misterHonorarerIPerioden = MisterHonorarerFraVervIPerioden.MISTER_ALLE_HONORARER,
                 arbeidsforhold = Arbeidsforhold(
                     normalarbeidstid = NormalArbeidstid(
                         timerPerUkeISnitt = Duration.ofHours(37).plusMinutes(30)

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/FrilansTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/FrilansTest.kt
@@ -40,8 +40,6 @@ class FrilansTest {
     fun `Frilans med valideringsfeil i arbeidsforhold`() {
         Frilans(
             startdato = LocalDate.parse("2020-01-01"),
-            sluttdato = null,
-            jobberFortsattSomFrilans = true,
             harInntektSomFrilanser = true,
             arbeidsforhold = Arbeidsforhold(
                 normalarbeidstid = NormalArbeidstid(
@@ -62,54 +60,16 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans hvor sluttdato er før startdato skal gi valideringsfeil`() {
-        Frilans(
-            startdato = LocalDate.parse("2020-01-01"),
-            sluttdato = LocalDate.parse("2019-01-01"),
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = null
-        )
-            .valider("test")
-            .verifiserFeil(1, listOf("test.sluttdato kan ikke være etter startdato"))
-    }
-
-    @Test
-    fun `Frilans hvor sluttdato og startdato er lik skal ikke gi valideringsfeil`() {
-        Frilans(
-            startdato = LocalDate.parse("2020-01-01"),
-            sluttdato = LocalDate.parse("2020-01-01"),
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = null
-        ).valider("test").verifiserIngenFeil()
-    }
-
-    @Test
-    fun `Frilans hvor sluttdato er etter startdato skal ikke gi valideringsfeil`() {
-        Frilans(
-            startdato = LocalDate.parse("2020-01-01"),
-            sluttdato = LocalDate.parse("2021-01-01"),
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = null
-        ).valider("test").verifiserIngenFeil()
-    }
-
-    @Test
     fun `Frilans hvor harInntektSomFrilanser er true med startdato og jobberFortsattSomFrilans som null gir feil`() {
         Frilans(
             startdato = null,
-            sluttdato = LocalDate.parse("2029-01-01"),
-            jobberFortsattSomFrilans = null,
             harInntektSomFrilanser = true,
             arbeidsforhold = null
         )
             .valider("test")
             .verifiserFeil(
-                2, listOf(
-                    "test.startdao kan ikke være null dersom harInntektSomFrilanser=true",
-                    "test.jobberFortsattSomFrilans kan ikke være null dersom harInntektSomFrilanser=true"
+                1, listOf(
+                    "test.startdato kan ikke være null dersom harInntektSomFrilanser=true"
                 )
             )
     }
@@ -118,8 +78,6 @@ class FrilansTest {
     fun `Frilans jobber som vanlig i hele søknadsperioden`() {
         val frilans = Frilans(
             startdato = LocalDate.parse("2020-01-01"),
-            sluttdato = null,
-            jobberFortsattSomFrilans = true,
             harInntektSomFrilanser = true,
             arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke
         )
@@ -145,84 +103,9 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans som sluttet i søknadsperioden med normaltid oppgitt som snittPerUke`() {
-        val frilans = Frilans(
-            startdato = mandag,
-            sluttdato = torsdag,
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke
-        )
-        val k9ArbeidstidInfo = frilans.k9ArbeidstidInfo(mandag, fredag)
-        val perioder = k9ArbeidstidInfo.perioder
-        assertEquals(2, perioder.size)
-
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, torsdag)]!!.jobberNormaltTimerPerDag)
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, torsdag)]!!.faktiskArbeidTimerPerDag)
-
-        assertEquals(NULL_TIMER, perioder[Periode(fredag, fredag)]!!.jobberNormaltTimerPerDag)
-        assertEquals(NULL_TIMER, perioder[Periode(fredag, fredag)]!!.faktiskArbeidTimerPerDag)
-    }
-
-    @Test
-    fun `Frilans som sluttet første dag i søknadsperioden med normaltid oppgitt som snittPerUke`() {
-        val frilans = Frilans(
-            startdato = mandag,
-            sluttdato = mandag,
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke
-        )
-        val k9ArbeidstidInfo = frilans.k9ArbeidstidInfo(mandag, fredag)
-        val perioder = k9ArbeidstidInfo.perioder
-        assertEquals(2, perioder.size)
-
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, mandag)]!!.jobberNormaltTimerPerDag)
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, mandag)]!!.faktiskArbeidTimerPerDag)
-
-        assertEquals(NULL_TIMER, perioder[Periode(tirsdag, fredag)]!!.jobberNormaltTimerPerDag)
-        assertEquals(NULL_TIMER, perioder[Periode(tirsdag, fredag)]!!.faktiskArbeidTimerPerDag)
-    }
-
-    @Test
-    fun `Frilans som sluttet siste dag i søknadsperioden med normaltid oppgitt som snittPerUke`() {
-        val frilans = Frilans(
-            startdato = mandag,
-            sluttdato = fredag,
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke
-        )
-        val k9ArbeidstidInfo = frilans.k9ArbeidstidInfo(mandag, fredag)
-        val perioder = k9ArbeidstidInfo.perioder
-        assertEquals(1, perioder.size)
-
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, fredag)]!!.jobberNormaltTimerPerDag)
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, fredag)]!!.faktiskArbeidTimerPerDag)
-    }
-
-    @Test
-    fun `Frilans som sluttet etter søknadsperioden med normaltid oppgitt som snittPerUke`() {
-        val frilans = Frilans(
-            startdato = mandag,
-            sluttdato = fredag,
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke
-        )
-        val k9ArbeidstidInfo = frilans.k9ArbeidstidInfo(mandag, torsdag)
-        val perioder = k9ArbeidstidInfo.perioder
-        assertEquals(1, perioder.size)
-
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, torsdag)]!!.jobberNormaltTimerPerDag)
-        assertEquals(syvOgEnHalvTime, perioder[Periode(mandag, torsdag)]!!.faktiskArbeidTimerPerDag)
-    }
-
-    @Test
     fun `Frilans som startet etter søknadsperioden startet med normaltid oppgitt som snittPerUke`() {
         val frilans = Frilans(
             startdato = onsdag,
-            jobberFortsattSomFrilans = true,
             harInntektSomFrilanser = true,
             arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke
         )
@@ -238,33 +121,9 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans som startet og sluttet i søknadsperioden med normaltid oppgitt som snittPerUke`() {
-        val frilans = Frilans(
-            startdato = tirsdag,
-            sluttdato = torsdag,
-            jobberFortsattSomFrilans = true,
-            harInntektSomFrilanser = true,
-            arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke
-        )
-        val k9ArbeidstidInfo = frilans.k9ArbeidstidInfo(mandag, fredag)
-        val perioder = k9ArbeidstidInfo.perioder
-        assertEquals(3, perioder.size)
-
-        listOf(mandag, fredag).forEach { dag ->
-            assertEquals(NULL_TIMER, perioder[Periode(dag, dag)]!!.jobberNormaltTimerPerDag)
-            assertEquals(NULL_TIMER, perioder[Periode(dag, dag)]!!.faktiskArbeidTimerPerDag)
-        }
-
-        assertEquals(syvOgEnHalvTime, perioder[Periode(tirsdag, torsdag)]!!.jobberNormaltTimerPerDag)
-        assertEquals(syvOgEnHalvTime, perioder[Periode(tirsdag, torsdag)]!!.faktiskArbeidTimerPerDag)
-    }
-
-    @Test
     fun `Frilanser som mister honorarer må ha misterHonorarerIPerioden satt`() {
         Frilans(
             startdato = LocalDate.parse("2020-01-01"),
-            sluttdato = null,
-            jobberFortsattSomFrilans = true,
             harInntektSomFrilanser = true,
             arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke,
             frilansTyper = listOf(FrilansType.STYREVERV, FrilansType.FRILANS),

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/FrilansTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/FrilansTest.kt
@@ -9,6 +9,7 @@ import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.arbeid.
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.arbeid.Arbeidsforhold
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.arbeid.NULL_TIMER
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Frilans
+import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.FrilansType
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.arbeid.NormalArbeidstid
 import java.time.Duration
 import java.time.LocalDate
@@ -17,7 +18,7 @@ import kotlin.test.assertEquals
 
 class FrilansTest {
 
-    companion object{
+    companion object {
         private val syvOgEnHalvTime = Duration.ofHours(7).plusMinutes(30)
         val mandag = LocalDate.parse("2022-01-03")
         val tirsdag = mandag.plusDays(1)
@@ -36,7 +37,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans med valideringsfeil i arbeidsforhold`(){
+    fun `Frilans med valideringsfeil i arbeidsforhold`() {
         Frilans(
             startdato = LocalDate.parse("2020-01-01"),
             sluttdato = null,
@@ -49,16 +50,19 @@ class FrilansTest {
                 arbeidIPeriode = ArbeidIPeriode(
                     type = ArbeidIPeriodeType.ARBEIDER_PROSENT_AV_NORMALT,
                     arbeiderIPerioden = ArbeiderIPeriodenSvar.SOM_VANLIG,
-                   prosentAvNormalt = null
+                    prosentAvNormalt = null
                 )
             )
         )
             .valider("test")
-            .verifiserFeil(1, listOf("test.arbeidsforhold.arbeidIPeriode.prosentAvNormalt må være satt dersom type=ARBEIDER_PROSENT_AV_NORMALT"))
+            .verifiserFeil(
+                1,
+                listOf("test.arbeidsforhold.arbeidIPeriode.prosentAvNormalt må være satt dersom type=ARBEIDER_PROSENT_AV_NORMALT")
+            )
     }
 
     @Test
-    fun `Frilans hvor sluttdato er før startdato skal gi valideringsfeil`(){
+    fun `Frilans hvor sluttdato er før startdato skal gi valideringsfeil`() {
         Frilans(
             startdato = LocalDate.parse("2020-01-01"),
             sluttdato = LocalDate.parse("2019-01-01"),
@@ -71,7 +75,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans hvor sluttdato og startdato er lik skal ikke gi valideringsfeil`(){
+    fun `Frilans hvor sluttdato og startdato er lik skal ikke gi valideringsfeil`() {
         Frilans(
             startdato = LocalDate.parse("2020-01-01"),
             sluttdato = LocalDate.parse("2020-01-01"),
@@ -82,7 +86,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans hvor sluttdato er etter startdato skal ikke gi valideringsfeil`(){
+    fun `Frilans hvor sluttdato er etter startdato skal ikke gi valideringsfeil`() {
         Frilans(
             startdato = LocalDate.parse("2020-01-01"),
             sluttdato = LocalDate.parse("2021-01-01"),
@@ -93,7 +97,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans hvor harInntektSomFrilanser er true med startdato og jobberFortsattSomFrilans som null gir feil`(){
+    fun `Frilans hvor harInntektSomFrilanser er true med startdato og jobberFortsattSomFrilans som null gir feil`() {
         Frilans(
             startdato = null,
             sluttdato = LocalDate.parse("2029-01-01"),
@@ -102,14 +106,16 @@ class FrilansTest {
             arbeidsforhold = null
         )
             .valider("test")
-            .verifiserFeil(2, listOf(
-                "test.startdao kan ikke være null dersom harInntektSomFrilanser=true",
-                "test.jobberFortsattSomFrilans kan ikke være null dersom harInntektSomFrilanser=true"
-            ))
+            .verifiserFeil(
+                2, listOf(
+                    "test.startdao kan ikke være null dersom harInntektSomFrilanser=true",
+                    "test.jobberFortsattSomFrilans kan ikke være null dersom harInntektSomFrilanser=true"
+                )
+            )
     }
 
     @Test
-    fun `Frilans jobber som vanlig i hele søknadsperioden`(){
+    fun `Frilans jobber som vanlig i hele søknadsperioden`() {
         val frilans = Frilans(
             startdato = LocalDate.parse("2020-01-01"),
             sluttdato = null,
@@ -126,7 +132,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans uten arbeidsforhold, forventer at hele søknadsperioden fylles med 0-0 timer`(){
+    fun `Frilans uten arbeidsforhold, forventer at hele søknadsperioden fylles med 0-0 timer`() {
         val frilans = Frilans(
             harInntektSomFrilanser = false
         )
@@ -139,7 +145,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans som sluttet i søknadsperioden med normaltid oppgitt som snittPerUke`(){
+    fun `Frilans som sluttet i søknadsperioden med normaltid oppgitt som snittPerUke`() {
         val frilans = Frilans(
             startdato = mandag,
             sluttdato = torsdag,
@@ -159,7 +165,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans som sluttet første dag i søknadsperioden med normaltid oppgitt som snittPerUke`(){
+    fun `Frilans som sluttet første dag i søknadsperioden med normaltid oppgitt som snittPerUke`() {
         val frilans = Frilans(
             startdato = mandag,
             sluttdato = mandag,
@@ -179,7 +185,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans som sluttet siste dag i søknadsperioden med normaltid oppgitt som snittPerUke`(){
+    fun `Frilans som sluttet siste dag i søknadsperioden med normaltid oppgitt som snittPerUke`() {
         val frilans = Frilans(
             startdato = mandag,
             sluttdato = fredag,
@@ -196,7 +202,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans som sluttet etter søknadsperioden med normaltid oppgitt som snittPerUke`(){
+    fun `Frilans som sluttet etter søknadsperioden med normaltid oppgitt som snittPerUke`() {
         val frilans = Frilans(
             startdato = mandag,
             sluttdato = fredag,
@@ -213,7 +219,7 @@ class FrilansTest {
     }
 
     @Test
-    fun `Frilans som startet etter søknadsperioden startet med normaltid oppgitt som snittPerUke`(){
+    fun `Frilans som startet etter søknadsperioden startet med normaltid oppgitt som snittPerUke`() {
         val frilans = Frilans(
             startdato = onsdag,
             jobberFortsattSomFrilans = true,
@@ -227,12 +233,12 @@ class FrilansTest {
         assertEquals(NULL_TIMER, perioder[Periode(mandag, tirsdag)]!!.jobberNormaltTimerPerDag)
         assertEquals(NULL_TIMER, perioder[Periode(mandag, tirsdag)]!!.faktiskArbeidTimerPerDag)
 
-        assertEquals(syvOgEnHalvTime, perioder[Periode(onsdag, fredag )]!!.jobberNormaltTimerPerDag)
+        assertEquals(syvOgEnHalvTime, perioder[Periode(onsdag, fredag)]!!.jobberNormaltTimerPerDag)
         assertEquals(syvOgEnHalvTime, perioder[Periode(onsdag, fredag)]!!.faktiskArbeidTimerPerDag)
     }
 
     @Test
-    fun `Frilans som startet og sluttet i søknadsperioden med normaltid oppgitt som snittPerUke`(){
+    fun `Frilans som startet og sluttet i søknadsperioden med normaltid oppgitt som snittPerUke`() {
         val frilans = Frilans(
             startdato = tirsdag,
             sluttdato = torsdag,
@@ -251,5 +257,24 @@ class FrilansTest {
 
         assertEquals(syvOgEnHalvTime, perioder[Periode(tirsdag, torsdag)]!!.jobberNormaltTimerPerDag)
         assertEquals(syvOgEnHalvTime, perioder[Periode(tirsdag, torsdag)]!!.faktiskArbeidTimerPerDag)
+    }
+
+    @Test
+    fun `Frilanser som mister honorarer må ha misterHonorarerIPerioden satt`() {
+        Frilans(
+            startdato = LocalDate.parse("2020-01-01"),
+            sluttdato = null,
+            jobberFortsattSomFrilans = true,
+            harInntektSomFrilanser = true,
+            arbeidsforhold = arbeidsforholdMedNormaltidSomSnittPerUke,
+            frilansTyper = listOf(FrilansType.STYREVERV, FrilansType.FRILANS),
+            misterHonorarer = true,
+            misterHonorarerIPerioden = null
+        ).valider("test")
+            .verifiserFeil(
+                1, listOf(
+                    "test.misterHonorarerIPerioden kan ikke være null dersom misterHonorarer=true",
+                )
+            )
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/SerDesTest.kt
@@ -257,8 +257,6 @@ internal class SerDesTest {
               },
               "frilans": {
                 "startdato": "2018-01-01",
-                "sluttdato": null,
-                "jobberFortsattSomFrilans": true,
                 "harInntektSomFrilanser": true,
                 "frilansTyper": ["FRILANS", "STYREVERV"],
                 "misterHonorarer": true,
@@ -520,10 +518,8 @@ internal class SerDesTest {
                 "tilleggsinformasjon": "Ikke beredskap"
               },
               "frilans": {
-                  "jobberFortsattSomFrilans": true,
                   "harInntektSomFrilanser": true,
                   "startdato": "2018-01-01",
-                  "sluttdato": null,
                   "frilansTyper": ["FRILANS", "STYREVERV"],
                   "misterHonorarer": true,
                   "misterHonorarerIPerioden": "MISTER_ALLE_HONORARER",
@@ -745,7 +741,6 @@ internal class SerDesTest {
             ),
             frilans = Frilans(
                 harInntektSomFrilanser = true,
-                jobberFortsattSomFrilans = true,
                 startdato = LocalDate.parse("2018-01-01"),
                 frilansTyper = listOf(FrilansType.FRILANS, FrilansType.STYREVERV),
                 misterHonorarer = true,

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/SerDesTest.kt
@@ -22,8 +22,10 @@ import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Bosted
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Ferieuttak
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.FerieuttakIPerioden
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Frilans
+import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.FrilansType
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.KomplettSøknad
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Medlemskap
+import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.MisterHonorarerFraVervIPerioden
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Nattevåk
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.OpptjeningIUtlandet
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.OpptjeningType
@@ -258,6 +260,9 @@ internal class SerDesTest {
                 "sluttdato": null,
                 "jobberFortsattSomFrilans": true,
                 "harInntektSomFrilanser": true,
+                "frilansTyper": ["FRILANS", "STYREVERV"],
+                "misterHonorarer": true,
+                "misterHonorarerIPerioden": "MISTER_ALLE_HONORARER",
                 "arbeidsforhold": {
                   "normalarbeidstid": {
                     "timerPerUkeISnitt": "PT37H30M"
@@ -519,6 +524,9 @@ internal class SerDesTest {
                   "harInntektSomFrilanser": true,
                   "startdato": "2018-01-01",
                   "sluttdato": null,
+                  "frilansTyper": ["FRILANS", "STYREVERV"],
+                  "misterHonorarer": true,
+                  "misterHonorarerIPerioden": "MISTER_ALLE_HONORARER",
                   "arbeidsforhold": {
                     "normalarbeidstid": {
                       "timerPerUkeISnitt": "PT37H30M"
@@ -739,6 +747,9 @@ internal class SerDesTest {
                 harInntektSomFrilanser = true,
                 jobberFortsattSomFrilans = true,
                 startdato = LocalDate.parse("2018-01-01"),
+                frilansTyper = listOf(FrilansType.FRILANS, FrilansType.STYREVERV),
+                misterHonorarer = true,
+                misterHonorarerIPerioden = MisterHonorarerFraVervIPerioden.MISTER_ALLE_HONORARER,
                 arbeidsforhold = Arbeidsforhold(
                     normalarbeidstid = NormalArbeidstid(
                         timerPerUkeISnitt = Duration.ofHours(37).plusMinutes(30)


### PR DESCRIPTION
Fjerner `jobberFortsattSomFrilans` og `sluttdato` fra frilanser i PSB.

Som konsekevens av at `sluttdato` fjernes, fjerner man også følgende mapping av arbeidstid:
- Fjerner mapping av arbeidstid der frilanser starter og slutter i søknadsperioden.
- Fjerner mapping av arbeidstid der frilanser slutter i søknadsperioden.

Legger til støtte for at søker at kan oppgi om hen mister honorarer, og om hen mister hele eller deler av det.