### PR TITLE
Utleder og sender ytelse til k9-selvbetjening-oppslag.

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingService.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/innsending/InnsendingService.kt
@@ -31,8 +31,8 @@ class InnsendingService(
     private val vedleggService: VedleggService,
 ) {
 
-    internal suspend fun registrer(innsending: Innsending, callId: CallId, idToken: IdToken, metadata: Metadata) {
-        val søker = søkerService.hentSøker(idToken, callId)
+    internal suspend fun registrer(innsending: Innsending, callId: CallId, idToken: IdToken, metadata: Metadata, ytelse: Ytelse) {
+        val søker = søkerService.hentSøker(idToken, callId, ytelse)
 
         logger.info(formaterStatuslogging(innsending.ytelse(), innsending.søknadId(), "registreres."))
 

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/OppslagUtils.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/OppslagUtils.kt
@@ -29,6 +29,6 @@ fun genererOppslagHttpRequest(
             HttpHeaders.Authorization to "Bearer ${idToken.value}",
             HttpHeaders.Accept to MediaTypeUtils.APPLICATION_JSON,
             HttpHeaders.XCorrelationId to callId.value,
-            "X-K9-YTELSE" to ytelse
+            "X-K9-Ytelse" to ytelse
         )
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/OppslagUtils.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/OppslagUtils.kt
@@ -8,6 +8,7 @@ import no.nav.helse.dusseldorf.ktor.auth.IdToken
 import no.nav.helse.dusseldorf.ktor.client.buildURL
 import no.nav.k9brukerdialogapi.general.CallId
 import no.nav.k9brukerdialogapi.utils.MediaTypeUtils
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import java.net.URI
 
 fun genererOppslagHttpRequest(
@@ -15,7 +16,8 @@ fun genererOppslagHttpRequest(
     baseUrl: URI,
     attributter: List<Pair<String, List<String>>>,
     idToken: IdToken,
-    callId: CallId
+    callId: CallId,
+    ytelse: Ytelse
 ): Request {
     return Url.buildURL(
         baseUrl = baseUrl,
@@ -26,6 +28,7 @@ fun genererOppslagHttpRequest(
         .header(
             HttpHeaders.Authorization to "Bearer ${idToken.value}",
             HttpHeaders.Accept to MediaTypeUtils.APPLICATION_JSON,
-            HttpHeaders.XCorrelationId to callId.value
+            HttpHeaders.XCorrelationId to callId.value,
+            "X-K9-YTELSE" to ytelse
         )
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/arbeidsgiver/ArbeidsgiverApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/arbeidsgiver/ArbeidsgiverApis.kt
@@ -11,6 +11,7 @@ import no.nav.k9brukerdialogapi.ARBEIDSGIVER_URL
 import no.nav.k9brukerdialogapi.general.getCallId
 import no.nav.k9brukerdialogapi.oppslag.TilgangNektetException
 import no.nav.k9brukerdialogapi.oppslag.respondTilgangNektetProblemDetail
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 
@@ -39,7 +40,8 @@ fun Route.arbeidsgiverApis(
                 fraOgMed = LocalDate.parse(fraOgMed),
                 tilOgMed = LocalDate.parse(tilOgMed),
                 skalHentePrivateArbeidsgivere = call.request.queryParameters[privateArbeidsgivereQueryName].toBoolean(),
-                skalHenteFrilansoppdrag  = call.request.queryParameters[frilansoppdragQueryName].toBoolean()
+                skalHenteFrilansoppdrag  = call.request.queryParameters[frilansoppdragQueryName].toBoolean(),
+                ytelse = call.ytelseFraHeader()
             )
 
             call.respond(arbeidsgivere)

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/arbeidsgiver/ArbeidsgiverGateway.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/arbeidsgiver/ArbeidsgiverGateway.kt
@@ -12,6 +12,7 @@ import no.nav.k9brukerdialogapi.k9SelvbetjeningOppslagKonfigurert
 import no.nav.k9brukerdialogapi.oppslag.genererOppslagHttpRequest
 import no.nav.k9brukerdialogapi.utils.LoggingUtils.logTokenExchange
 import no.nav.k9brukerdialogapi.utils.MediaTypeUtils
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
@@ -30,14 +31,16 @@ class ArbeidsgiverGateway(
     internal suspend fun hentArbeidsgivere(
         idToken: IdToken,
         callId: CallId,
-        attributter: List<Pair<String, List<String>>>
+        attributter: List<Pair<String, List<String>>>,
+        ytelse: Ytelse
     ): Arbeidsgivere {
         val exchangeToken = IdToken(accessTokenClient.getAccessToken(k9SelvbetjeningOppslagTokenxAudience, idToken.value).token)
         logger.logTokenExchange(idToken, exchangeToken)
 
         val httpRequest = genererOppslagHttpRequest(
-            baseUrl = baseUrl, idToken = exchangeToken, callId = callId, pathParts = "meg",
-            attributter = attributter
+            pathParts = "meg", baseUrl = baseUrl, attributter = attributter, idToken = exchangeToken,
+            callId = callId,
+            ytelse = ytelse
         )
 
         val arbeidsgivereOppslagRespons = Retry.retry(

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/arbeidsgiver/ArbeidsgiverService.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/arbeidsgiver/ArbeidsgiverService.kt
@@ -3,6 +3,7 @@ package no.nav.k9brukerdialogapi.oppslag.arbeidsgiver
 import no.nav.helse.dusseldorf.ktor.auth.IdToken
 import no.nav.k9brukerdialogapi.general.CallId
 import no.nav.k9brukerdialogapi.oppslag.TilgangNektetException
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
@@ -29,7 +30,8 @@ class ArbeidsgiverService(
         fraOgMed: LocalDate,
         tilOgMed: LocalDate,
         skalHentePrivateArbeidsgivere: Boolean,
-        skalHenteFrilansoppdrag: Boolean
+        skalHenteFrilansoppdrag: Boolean,
+        ytelse: Ytelse
     ): Arbeidsgivere = try {
         arbeidsgivereGateway.hentArbeidsgivere(
             idToken,
@@ -38,7 +40,8 @@ class ArbeidsgiverService(
                 Pair("a", genererAttributter(skalHentePrivateArbeidsgivere, skalHenteFrilansoppdrag)),
                 Pair("fom", listOf(DateTimeFormatter.ISO_LOCAL_DATE.format(fraOgMed))),
                 Pair("tom", listOf(DateTimeFormatter.ISO_LOCAL_DATE.format(tilOgMed)))
-            )
+            ),
+            ytelse = ytelse
         )
     } catch (cause: Throwable) {
         when (cause) {

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/barn/BarnApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/barn/BarnApis.kt
@@ -9,6 +9,7 @@ import no.nav.k9brukerdialogapi.BARN_URL
 import no.nav.k9brukerdialogapi.general.getCallId
 import no.nav.k9brukerdialogapi.oppslag.TilgangNektetException
 import no.nav.k9brukerdialogapi.oppslag.respondTilgangNektetProblemDetail
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger("no.nav.k9brukerdialogapi.oppslag.barn.barnApis")
@@ -22,7 +23,8 @@ fun Route.barnApis(
         try {
             val barn = barnService.hentBarn(
                 idToken = idTokenProvider.getIdToken(call),
-                callId = call.getCallId()
+                callId = call.getCallId(),
+                ytelse = call.ytelseFraHeader()
             )
             call.respond(BarnOppslagListe(barn))
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/barn/BarnGateway.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/barn/BarnGateway.kt
@@ -12,6 +12,7 @@ import no.nav.k9brukerdialogapi.k9SelvbetjeningOppslagKonfigurert
 import no.nav.k9brukerdialogapi.oppslag.genererOppslagHttpRequest
 import no.nav.k9brukerdialogapi.oppslag.throwable
 import no.nav.k9brukerdialogapi.utils.LoggingUtils.logTokenExchange
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
@@ -38,17 +39,19 @@ class BarnGateway(
 
     suspend fun hentBarn(
         idToken: IdToken,
-        callId: CallId
+        callId: CallId,
+        ytelse: Ytelse
     ): List<BarnOppslagRespons> {
         val exchangeToken = IdToken(accessTokenClient.getAccessToken(k9SelvbetjeningOppslagTokenxAudience, idToken.value).token)
         logger.logTokenExchange(idToken, exchangeToken)
 
         val httpRequest = genererOppslagHttpRequest(
-            baseUrl = baseUrl,
             pathParts = "meg",
+            baseUrl = baseUrl,
             attributter = listOf(attributter),
             idToken = exchangeToken,
-            callId = callId
+            callId = callId,
+            ytelse = ytelse
 
         )
 

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/barn/BarnService.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/barn/BarnService.kt
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache
 import no.nav.helse.dusseldorf.ktor.auth.IdToken
 import no.nav.k9brukerdialogapi.general.CallId
 import no.nav.k9brukerdialogapi.oppslag.TilgangNektetException
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -15,7 +16,8 @@ class BarnService(
 
     internal suspend fun hentBarn(
         idToken: IdToken,
-        callId: CallId
+        callId: CallId,
+        ytelse: Ytelse
     ): List<BarnOppslag> {
         var barnFraCache = cache.getIfPresent(idToken.getNorskIdentifikasjonsnummer())
         if (barnFraCache != null) return barnFraCache
@@ -23,7 +25,8 @@ class BarnService(
         return try {
             val barn = barnGateway.hentBarn(
                 idToken = idToken,
-                callId = callId
+                callId = callId,
+                ytelse = ytelse
             ).map { it.tilBarnOppslag() }
 
             cache.put(idToken.getNorskIdentifikasjonsnummer(), barn)

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/søker/SøkerApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/søker/SøkerApis.kt
@@ -9,6 +9,7 @@ import no.nav.k9brukerdialogapi.SØKER_URL
 import no.nav.k9brukerdialogapi.general.getCallId
 import no.nav.k9brukerdialogapi.oppslag.TilgangNektetException
 import no.nav.k9brukerdialogapi.oppslag.respondTilgangNektetProblemDetail
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger("no.nav.k9brukerdialogapi.oppslag.søker.SøkerApis")
@@ -21,7 +22,8 @@ fun Route.søkerApis(
         try {
             val søker = søkerService.hentSøker(
                 idToken = idTokenProvider.getIdToken(call),
-                callId = call.getCallId()
+                callId = call.getCallId(),
+                ytelse = call.ytelseFraHeader()
             )
             call.respond(søker)
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/søker/SøkerGateway.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/søker/SøkerGateway.kt
@@ -12,6 +12,7 @@ import no.nav.k9brukerdialogapi.k9SelvbetjeningOppslagKonfigurert
 import no.nav.k9brukerdialogapi.oppslag.genererOppslagHttpRequest
 import no.nav.k9brukerdialogapi.oppslag.throwable
 import no.nav.k9brukerdialogapi.utils.LoggingUtils.logTokenExchange
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
@@ -29,7 +30,8 @@ class SøkerGateway(
 
     suspend fun hentSøker(
         idToken: IdToken,
-        callId: CallId
+        callId: CallId,
+        ytelse: Ytelse
     ): Søker {
         val exchangeToken = IdToken(accessTokenClient.getAccessToken(k9SelvbetjeningOppslagTokenxAudience, idToken.value).token)
         logger.logTokenExchange(idToken, exchangeToken)
@@ -39,7 +41,8 @@ class SøkerGateway(
             pathParts = "meg",
             attributter = listOf(attributter),
             idToken = exchangeToken,
-            callId = callId
+            callId = callId,
+            ytelse = ytelse
         )
 
         val oppslagRespons = Retry.retry(

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/søker/SøkerService.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/oppslag/søker/SøkerService.kt
@@ -2,14 +2,16 @@ package no.nav.k9brukerdialogapi.oppslag.søker
 
 import no.nav.helse.dusseldorf.ktor.auth.IdToken
 import no.nav.k9brukerdialogapi.general.CallId
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 
 class SøkerService (
     private val søkerGateway: SøkerGateway
 ) {
     suspend fun hentSøker(
         idToken: IdToken,
-        callId: CallId
+        callId: CallId,
+        ytelse: Ytelse
     ): Søker {
-        return søkerGateway.hentSøker(idToken, callId)
+        return søkerGateway.hentSøker(idToken, callId, ytelse)
     }
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/Ytelse.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/Ytelse.kt
@@ -1,16 +1,28 @@
 package no.nav.k9brukerdialogapi.ytelse
 
-enum class Ytelse {
-    OMSORGSPENGER_UTVIDET_RETT,
-    OMSORGSPENGER_MIDLERTIDIG_ALENE,
-    ETTERSENDING,
-    OMSORGSDAGER_ALENEOMSORG,
-    OMSORGSPENGER_UTBETALING_ARBEIDSTAKER,
-    OMSORGSPENGER_UTBETALING_SNF,
-    PLEIEPENGER_LIVETS_SLUTTFASE,
-    ETTERSENDING_PLEIEPENGER_SYKT_BARN,
-    ETTERSENDING_PLEIEPENGER_LIVETS_SLUTTFASE,
-    ETTERSENDING_OMP,
-    PLEIEPENGER_SYKT_BARN,
-    ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN
+import io.ktor.server.application.ApplicationCall
+
+enum class Ytelse(val dialog: String) {
+    OMSORGSPENGER_UTVIDET_RETT("omsorgspengesoknad"),
+    OMSORGSPENGER_MIDLERTIDIG_ALENE("ekstra-omsorgsdager-andre-forelder-ikke-tilsyn"),
+    ETTERSENDING("sif-ettersending"),
+    OMSORGSDAGER_ALENEOMSORG("omsorgsdager-aleneomsorg-dialog"),
+    OMSORGSPENGER_UTBETALING_ARBEIDSTAKER("omsorgspengerutbetaling-arbeidstaker-soknad"),
+    OMSORGSPENGER_UTBETALING_SNF("omsorgspengerutbetaling-soknad"),
+    PLEIEPENGER_LIVETS_SLUTTFASE("pleiepenger-i-livets-sluttfase-soknad"),
+    ETTERSENDING_PLEIEPENGER_SYKT_BARN("sif-ettersending"),
+    ETTERSENDING_PLEIEPENGER_LIVETS_SLUTTFASE("sif-ettersending"),
+    ETTERSENDING_OMP("sif-ettersending"),
+    PLEIEPENGER_SYKT_BARN("pleiepengesoknad"),
+    ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN("endringsmelding-pleiepenger");
+}
+
+fun ApplicationCall.ytelseFraHeader(): Ytelse {
+    val k9BrukerdialogHeader =
+        request.headers["X-K9-Brukerdialog"] ?: throw IllegalArgumentException("Mangler header X-K9-Brukerdialog")
+
+    return runCatching { Ytelse.entries.first { it.dialog == k9BrukerdialogHeader.substringAfterLast(":") } }
+        .onSuccess { return it }
+        .onFailure { throw IllegalArgumentException("Ukjent dialog $k9BrukerdialogHeader") }
+        .getOrThrow()
 }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingApis.kt
@@ -17,6 +17,7 @@ import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.ytelse.ettersending.domene.Ettersendelse
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -32,12 +33,12 @@ fun Route.ettersendingApis(
             val ettersendelse =  call.receive<Ettersendelse>()
             val idToken = idTokenProvider.getIdToken(call)
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${ettersendelse.ytelse()}"
-
+            val ytelse = call.ytelseFraHeader()
 
             logger.info(formaterStatuslogging(ettersendelse.ytelse(), ettersendelse.søknadId, "mottatt."))
             logger.info("Ettersending for ytelse ${ettersendelse.søknadstype}")
             innsendingCache.put(cacheKey)
-            innsendingService.registrer(ettersendelse, call.getCallId(), idToken, call.getMetadata())
+            innsendingService.registrer(ettersendelse, call.getCallId(), idToken, call.getMetadata(), ytelse)
             registrerMottattSøknad(ettersendelse.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneApis.kt
@@ -18,6 +18,7 @@ import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengermidlertidigalene.domene.OmsorgspengerMdlertidigAleneSøknad
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -36,12 +37,13 @@ fun Route.omsorgspengerMidlertidigAleneApis(
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            val ytelse = call.ytelseFraHeader()
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
-            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))
+            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId, ytelse))
 
             innsendingCache.put(cacheKey)
-            innsendingService.registrer(søknad, callId, idToken, metadata)
+            innsendingService.registrer(søknad, callId, idToken, metadata, ytelse)
             registrerMottattSøknad(søknad.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerApi.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerApi.kt
@@ -17,6 +17,7 @@ import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.OmsorgspengerutbetalingArbeidstakerSøknad
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -32,11 +33,12 @@ fun Route.omsorgspengerUtbetalingArbeidstakerApi(
             val søknad =  call.receive<OmsorgspengerutbetalingArbeidstakerSøknad>()
             val idToken = idTokenProvider.getIdToken(call)
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            val ytelse = call.ytelseFraHeader()
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
 
             innsendingCache.put(cacheKey)
-            innsendingService.registrer(søknad, call.getCallId(), idToken, call.getMetadata())
+            innsendingService.registrer(søknad, call.getCallId(), idToken, call.getMetadata(), ytelse)
             registrerMottattSøknad(søknad.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfApis.kt
@@ -18,6 +18,7 @@ import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingsnf.domene.OmsorgspengerutbetalingSnfSøknad
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -36,12 +37,13 @@ fun Route.omsorgspengerUtbetalingSnfApis(
             val metadata = call.getMetadata()
             val idToken = idTokenProvider.getIdToken(call)
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            val ytelse = call.ytelseFraHeader()
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId.id, "mottatt."))
-            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))
+            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId, ytelse))
 
             innsendingCache.put(cacheKey)
-            innsendingService.registrer(søknad, callId, idToken, metadata)
+            innsendingService.registrer(søknad, callId, idToken, metadata, ytelse)
             registrerMottattSøknad(søknad.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettApis.kt
@@ -18,6 +18,7 @@ import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutvidetrett.domene.OmsorgspengerKroniskSyktBarnSøknad
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -36,12 +37,13 @@ fun Route.omsorgspengerUtvidetRettApis(
             val idToken = idTokenProvider.getIdToken(call)
             val metadata = call.getMetadata()
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
+            val ytelse = call.ytelseFraHeader()
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
-            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))
+            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId, ytelse))
 
             innsendingCache.put(cacheKey)
-            innsendingService.registrer(søknad, callId, idToken, metadata)
+            innsendingService.registrer(søknad, callId, idToken, metadata, ytelse)
             registrerMottattSøknad(søknad.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseApi.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseApi.kt
@@ -17,6 +17,7 @@ import no.nav.k9brukerdialogapi.innsending.InnsendingService
 import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.ytelse.pleiepengerlivetssluttfase.domene.PilsSøknad
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -32,10 +33,11 @@ fun Route.pleiepengerLivetsSluttfaseApi(
             val pilsSøknad = call.receive<PilsSøknad>()
             val idToken = idTokenProvider.getIdToken(call)
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${pilsSøknad.ytelse()}"
+            val ytelse = call.ytelseFraHeader()
 
             logger.info(formaterStatuslogging(pilsSøknad.ytelse(), pilsSøknad.søknadId, "mottatt."))
             innsendingCache.put(cacheKey)
-            innsendingService.registrer(pilsSøknad, call.getCallId(), idToken, call.getMetadata())
+            innsendingService.registrer(pilsSøknad, call.getCallId(), idToken, call.getMetadata(), ytelse)
             registrerMottattSøknad(pilsSøknad.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/endringsmelding/EndringsmeldingApis.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/endringsmelding/EndringsmeldingApis.kt
@@ -22,6 +22,7 @@ import no.nav.k9brukerdialogapi.oppslag.barn.BarnOppslag
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.endringsmelding.domene.Endringsmelding
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -42,8 +43,9 @@ fun Route.endringsmeldingApis(
             val idToken = idTokenProvider.getIdToken(call)
             val metadata = call.getMetadata()
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${endringsmelding.ytelse()}"
+            val ytelseFraHeader = call.ytelseFraHeader()
 
-            val barn: BarnOppslag = barnFraEndringsmelding(barnService.hentBarn(idToken, callId), endringsmelding)
+            val barn: BarnOppslag = barnFraEndringsmelding(barnService.hentBarn(idToken, callId, ytelseFraHeader), endringsmelding)
 
             logger.info(formaterStatuslogging(endringsmelding.ytelse(), endringsmelding.søknadId, "mottatt."))
 
@@ -53,7 +55,7 @@ fun Route.endringsmeldingApis(
             endringsmelding.gyldigeEndringsPerioder = ytelse.søknadsperiodeList
             endringsmelding.pleietrengendeNavn = barn.navn()
 
-            innsendingService.registrer(endringsmelding, callId, idToken, metadata)
+            innsendingService.registrer(endringsmelding, callId, idToken, metadata, ytelseFraHeader)
             innsendingCache.put(cacheKey)
             registrerMottattSøknad(endringsmelding.ytelse())
             call.respond(HttpStatusCode.Accepted)

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/PleiepengerSyktBarnApi.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/PleiepengerSyktBarnApi.kt
@@ -18,6 +18,7 @@ import no.nav.k9brukerdialogapi.kafka.getMetadata
 import no.nav.k9brukerdialogapi.oppslag.barn.BarnService
 import no.nav.k9brukerdialogapi.ytelse.pleiepengersyktbarn.soknad.domene.Søknad
 import no.nav.k9brukerdialogapi.ytelse.registrerMottattSøknad
+import no.nav.k9brukerdialogapi.ytelse.ytelseFraHeader
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -34,13 +35,14 @@ fun Route.pleiepengerSyktBarnApi(
             val søknad = call.receive<Søknad>()
             val idToken = idTokenProvider.getIdToken(call)
             val callId = call.getCallId()
+            val ytelse = call.ytelseFraHeader()
             val cacheKey = "${idToken.getNorskIdentifikasjonsnummer()}_${søknad.ytelse()}"
 
             logger.info(formaterStatuslogging(søknad.ytelse(), søknad.søknadId, "mottatt."))
-            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId))
+            søknad.leggTilIdentifikatorPåBarnHvisMangler(barnService.hentBarn(idToken, callId, ytelse))
 
             innsendingCache.put(cacheKey)
-            innsendingService.registrer(søknad, callId, idToken, call.getMetadata())
+            innsendingService.registrer(søknad, callId, idToken, call.getMetadata(), ytelse)
             registrerMottattSøknad(søknad.ytelse())
             call.respond(HttpStatusCode.Accepted)
         }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/InnsendingServiceTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/InnsendingServiceTest.kt
@@ -19,6 +19,7 @@ import no.nav.k9brukerdialogapi.oppslag.søker.SøkerService
 import no.nav.k9brukerdialogapi.vedlegg.DokumentEier
 import no.nav.k9brukerdialogapi.vedlegg.Vedlegg
 import no.nav.k9brukerdialogapi.vedlegg.VedleggService
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import no.nav.k9brukerdialogapi.ytelse.ettersending.domene.Søknadstype
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.AktivitetFravær
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Barn
@@ -68,7 +69,7 @@ internal class InnsendingServiceTest{
     internal fun `Verifiser at søknadservice for ettersending fjerner hold på persistert vedlegg dersom kafka feiler`() {
         assertThrows<MeldingRegistreringFeiletException> {
             runBlocking {
-                coEvery {søkerService.hentSøker(any(), any()) } returns Søker(
+                coEvery {søkerService.hentSøker(any(), any(), any()) } returns Søker(
                     aktørId = "123",
                     fødselsdato = LocalDate.parse("2000-01-01"),
                     fødselsnummer = "02119970078"
@@ -94,7 +95,8 @@ internal class InnsendingServiceTest{
                         soknadDialogCommitSha = "abc-123"
                     ),
                     idToken = IdToken(Azure.V2_0.generateJwt(clientId = "ikke-authorized-client", audience = "omsorgsdager-melding-api")),
-                    callId = CallId("abc")
+                    callId = CallId("abc"),
+                    ytelse = Ytelse.ETTERSENDING
                 )
             }
         }
@@ -106,7 +108,7 @@ internal class InnsendingServiceTest{
     internal fun `Verifiser at søknadservice for omsorgspenger utvidet rett fjerner hold på persistert vedlegg dersom kafka feiler`() {
         assertThrows<MeldingRegistreringFeiletException> {
             runBlocking {
-                coEvery {søkerService.hentSøker(any(), any()) } returns Søker(
+                coEvery {søkerService.hentSøker(any(), any(), any()) } returns Søker(
                     aktørId = "123",
                     fødselsdato = LocalDate.parse("2000-01-01"),
                     fødselsnummer = "02119970078"
@@ -137,7 +139,8 @@ internal class InnsendingServiceTest{
                         soknadDialogCommitSha = "abc-123"
                     ),
                     idToken = IdToken(Azure.V2_0.generateJwt(clientId = "ikke-authorized-client", audience = "omsorgsdager-melding-api")),
-                    callId = CallId("abc")
+                    callId = CallId("abc"),
+                    ytelse = Ytelse.OMSORGSPENGER_UTVIDET_RETT
                 )
             }
         }
@@ -149,7 +152,7 @@ internal class InnsendingServiceTest{
     internal fun `Verifiser at søknadservice for omsorgspenger utbetaling arbeidstaker fjerner hold på persistert vedlegg dersom kafka feiler`() {
         assertThrows<MeldingRegistreringFeiletException> {
             runBlocking {
-                coEvery {søkerService.hentSøker(any(), any()) } returns Søker(
+                coEvery {søkerService.hentSøker(any(), any(), any()) } returns Søker(
                     aktørId = "123",
                     fødselsdato = LocalDate.parse("2000-01-01"),
                     fødselsnummer = "02119970078"
@@ -196,7 +199,8 @@ internal class InnsendingServiceTest{
                         soknadDialogCommitSha = "abc-123"
                     ),
                     idToken = IdToken(Azure.V2_0.generateJwt(clientId = "authorized-client", audience = "omsorgsdager-melding-api")),
-                    callId = CallId("abc")
+                    callId = CallId("abc"),
+                    ytelse = Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER
                 )
             }
         }
@@ -208,7 +212,7 @@ internal class InnsendingServiceTest{
     internal fun `Verifiser at søknadservice for omsorgspenger utbetaling snf fjerner hold på persistert vedlegg dersom kafka feiler`() {
         assertThrows<MeldingRegistreringFeiletException> {
             runBlocking {
-                coEvery {søkerService.hentSøker(any(), any()) } returns Søker(
+                coEvery {søkerService.hentSøker(any(), any(), any()) } returns Søker(
                     aktørId = "123",
                     fødselsdato = LocalDate.parse("2000-01-01"),
                     fødselsnummer = "02119970078"
@@ -257,7 +261,8 @@ internal class InnsendingServiceTest{
                         soknadDialogCommitSha = "abc-123"
                     ),
                     idToken = IdToken(Azure.V2_0.generateJwt(clientId = "authorized-client", audience = "k9-brukerdialog-api")),
-                    callId = CallId("abc")
+                    callId = CallId("abc"),
+                    ytelse = Ytelse.OMSORGSPENGER_UTBETALING_SNF
                 )
             }
         }
@@ -270,7 +275,7 @@ internal class InnsendingServiceTest{
     internal fun `Verifiser at søknadservice for pleiepenger livets sluttfase fjerner hold på persistert vedlegg dersom kafka feiler`(){
         assertThrows<MeldingRegistreringFeiletException> {
             runBlocking {
-                coEvery {søkerService.hentSøker(any(), any()) } returns Søker(
+                coEvery {søkerService.hentSøker(any(), any(), any()) } returns Søker(
                     aktørId = "123",
                     fødselsdato = LocalDate.parse("2000-01-01"),
                     fødselsnummer = "02119970078"
@@ -288,7 +293,8 @@ internal class InnsendingServiceTest{
                         soknadDialogCommitSha = "abc-123"
                     ),
                     idToken = IdToken(Azure.V2_0.generateJwt(clientId = "authorized-client", audience = "k9-brukerdialog-api")),
-                    callId = CallId("abc")
+                    callId = CallId("abc"),
+                    ytelse = Ytelse.ETTERSENDING_PLEIEPENGER_LIVETS_SLUTTFASE
                 )
             }
         }
@@ -300,7 +306,7 @@ internal class InnsendingServiceTest{
     internal fun `Verifiser at søknadservice for pleiepenger sykt barn fjerner hold på persistert vedlegg dersom kafka feiler`(){
         assertThrows<MeldingRegistreringFeiletException> {
             runBlocking {
-                coEvery {søkerService.hentSøker(any(), any()) } returns Søker(
+                coEvery {søkerService.hentSøker(any(), any(), any()) } returns Søker(
                     aktørId = "123",
                     fødselsdato = LocalDate.parse("2000-01-01"),
                     fødselsnummer = "02119970078"
@@ -322,7 +328,8 @@ internal class InnsendingServiceTest{
                         soknadDialogCommitSha = "abc-123"
                     ),
                     idToken = IdToken(Azure.V2_0.generateJwt(clientId = "authorized-client", audience = "k9-brukerdialog-api")),
-                    callId = CallId("abc")
+                    callId = CallId("abc"),
+                    ytelse = Ytelse.PLEIEPENGER_SYKT_BARN
                 )
             }
         }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/TestUtils.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/TestUtils.kt
@@ -9,6 +9,7 @@ import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import no.nav.helse.dusseldorf.ktor.auth.IdToken
 import no.nav.k9brukerdialogapi.utils.MediaTypeUtils.APPLICATION_JSON
+import no.nav.k9brukerdialogapi.ytelse.Ytelse
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -61,7 +62,8 @@ class TestUtils {
             jwtToken: String? = null,
             cookie: String? = null,
             logger: Logger,
-            engine: TestApplicationEngine
+            engine: TestApplicationEngine,
+            ytelse: Ytelse = Ytelse.PLEIEPENGER_SYKT_BARN
         ): String? {
             val respons: String?
             with(engine) {
@@ -71,7 +73,7 @@ class TestUtils {
                     logger.info("Request Entity = $requestEntity")
                     addHeader(HttpHeaders.Accept, APPLICATION_JSON)
                     addHeader(HttpHeaders.XCorrelationId, UUID.randomUUID().toString())
-                    addHeader("X-K9-Brukerdialog", "søknads-dialog")
+                    addHeader("X-K9-Brukerdialog", ytelse.dialog)
                     addHeader("X-Brukerdialog-Git-Sha", "abc-123")
                     if (requestEntity != null) addHeader(HttpHeaders.ContentType, APPLICATION_JSON)
                     if (requestEntity != null) setBody(requestEntity)

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/ettersending/EttersendingTest.kt
@@ -105,6 +105,7 @@ class EttersendingTest {
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true
         )
+        val ytelse = Ytelse.ETTERSENDING
         TestUtils.requestAndAssert(
             engine = engine,
             logger = logger,
@@ -113,9 +114,10 @@ class EttersendingTest {
             expectedCode = HttpStatusCode.Accepted,
             jwtToken = tokenXToken,
             expectedResponse = null,
-            requestEntity = søknad.somJson()
+            requestEntity = søknad.somJson(),
+            ytelse = ytelse
         )
-        val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId, Ytelse.ETTERSENDING)
+        val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId, ytelse)
         assertEquals(
             søknad.somKomplettSøknad(SøknadUtils.søker, søknad.somK9Format(SøknadUtils.søker, metadata), listOf("nav-logo.png")),
             hentet.data.somEttersendingKomplettSøknad()
@@ -155,7 +157,8 @@ class EttersendingTest {
                   "status": 400
                 }
             """.trimIndent(),
-            requestEntity = søknad.somJson()
+            requestEntity = søknad.somJson(),
+            ytelse = Ytelse.ETTERSENDING
         )
     }
 

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgsdageraleneomsorg/OmsorgsdagerAleneomsorgTest.kt
@@ -115,7 +115,8 @@ class OmsorgsdagerAleneomsorgTest {
             jwtToken = tokenXToken,
             requestEntity = søknad.somJson(),
             engine = engine,
-            logger = logger
+            logger = logger,
+            ytelse = Ytelse.OMSORGSDAGER_ALENEOMSORG
         )
         val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId, Ytelse.OMSORGSDAGER_ALENEOMSORG)
         assertEquals(
@@ -164,7 +165,8 @@ class OmsorgsdagerAleneomsorgTest {
                   ],
                   "status": 400
                 }
-                """.trimIndent()
+                """.trimIndent(),
+            ytelse = Ytelse.OMSORGSDAGER_ALENEOMSORG
         )
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengermidlertidigalene/OmsorgspengerMidlertidigAleneTest.kt
@@ -122,7 +122,8 @@ class OmsorgspengerMidlertidigAleneTest {
             jwtToken = tokenXToken,
             requestEntity = søknad.somJson(),
             engine = engine,
-            logger = logger
+            logger = logger,
+            ytelse = Ytelse.OMSORGSPENGER_MIDLERTIDIG_ALENE
         )
         val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId, Ytelse.OMSORGSPENGER_MIDLERTIDIG_ALENE)
         assertEquals(
@@ -179,7 +180,8 @@ class OmsorgspengerMidlertidigAleneTest {
                   ],
                   "status": 400
                 }
-                """.trimIndent()
+                """.trimIndent(),
+            ytelse = Ytelse.OMSORGSPENGER_MIDLERTIDIG_ALENE
         )
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/OmsorgspengerUtbetalingArbeidstakerTest.kt
@@ -142,7 +142,8 @@ class OmsorgspengerUtbetalingArbeidstakerTest {
             path = OMSORGSPENGER_UTBETALING_ARBEIDSTAKER_URL + INNSENDING_URL,
             expectedCode = HttpStatusCode.Accepted,
             jwtToken = tokenXToken,
-            requestEntity = søknad.somJson()
+            requestEntity = søknad.somJson(),
+            ytelse = Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER
         )
         val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId, Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER)
         assertEquals(
@@ -229,7 +230,8 @@ class OmsorgspengerUtbetalingArbeidstakerTest {
                 }
             """.trimIndent(),
             jwtToken = tokenXToken,
-            requestEntity = søknad.somJson()
+            requestEntity = søknad.somJson(),
+            ytelse = Ytelse.OMSORGSPENGER_UTBETALING_ARBEIDSTAKER
         )
     }
 

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingsnf/OmsorgspengerUtbetalingSnfTest.kt
@@ -103,6 +103,7 @@ class OmsorgspengerUtbetalingSnfTest {
     fun `Innsending av gyldig søknad`() {
         val vedlegg = URL(engine.jpegUrl(jwtToken = tokenXToken))
         val søknad = genererSøknadForOmsUtSnf(vedlegg = listOf(vedlegg))
+        val ytelse = Ytelse.OMSORGSPENGER_UTBETALING_SNF
         requestAndAssert(
             engine = engine,
             logger = logger,
@@ -110,9 +111,10 @@ class OmsorgspengerUtbetalingSnfTest {
             path = OMSORGSPENGER_UTBETALING_SNF_URL + INNSENDING_URL,
             expectedCode = HttpStatusCode.Accepted,
             jwtToken = tokenXToken,
-            requestEntity = søknad.somJson()
+            requestEntity = søknad.somJson(),
+            ytelse = ytelse
         )
-        val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId.id, Ytelse.OMSORGSPENGER_UTBETALING_SNF)
+        val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId.id, ytelse)
         assertEquals(
             søknad.somKomplettSøknad(SøknadUtils.søker, søknad.somK9Format(SøknadUtils.søker, metadata)),
             hentet.data.somOmsorgspengerUtbetalingSnfKomplettSøknad()
@@ -181,7 +183,8 @@ class OmsorgspengerUtbetalingSnfTest {
                 }
             """.trimIndent(),
             jwtToken = tokenXToken,
-            requestEntity = søknad.somJson()
+            requestEntity = søknad.somJson(),
+            ytelse = Ytelse.OMSORGSPENGER_UTBETALING_SNF
         )
     }
 

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutvidetrett/OmsorgspengerUtvidetRettTest.kt
@@ -107,6 +107,7 @@ class OmsorgspengerUtvidetRettTest {
             harBekreftetOpplysninger = true,
             harForståttRettigheterOgPlikter = true
         )
+        val ytelse = Ytelse.OMSORGSPENGER_UTVIDET_RETT
         requestAndAssert(
             engine = engine,
             logger = logger,
@@ -114,9 +115,10 @@ class OmsorgspengerUtvidetRettTest {
             path = OMSORGSPENGER_UTVIDET_RETT_URL + INNSENDING_URL,
             expectedCode = HttpStatusCode.Accepted,
             jwtToken = tokenXToken,
-            requestEntity = søknad.somJson()
+            requestEntity = søknad.somJson(),
+            ytelse = ytelse
         )
-        val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId, Ytelse.OMSORGSPENGER_UTVIDET_RETT)
+        val hentet = kafkaKonsumer.hentSøknad(søknad.søknadId, ytelse)
         assertEquals(
             søknad.somKomplettSøknad(SøknadUtils.søker, søknad.somK9Format(SøknadUtils.søker, metadata)),
             hentet.data.somOmsorgspengerUtvidetRettKomplettSøknad()
@@ -161,7 +163,8 @@ class OmsorgspengerUtvidetRettTest {
                   "status": 400
                 }
             """.trimIndent(),
-            requestEntity = søknad
+            requestEntity = søknad,
+            ytelse = Ytelse.OMSORGSPENGER_UTVIDET_RETT
         )
     }
 

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengerlivetssluttfase/PleiepengerLivetsSluttfaseTest.kt
@@ -99,6 +99,7 @@ class PleiepengerLivetsSluttfaseTest {
             vedleggUrls = listOf(vedlegg),
             opplastetIdVedleggUrls = listOf(vedlegg)
         )
+        val ytelse = Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE
         requestAndAssert(
             HttpMethod.Post,
             PLEIEPENGER_LIVETS_SLUTTFASE_URL+ INNSENDING_URL,
@@ -107,9 +108,10 @@ class PleiepengerLivetsSluttfaseTest {
             HttpStatusCode.Accepted,
             jwtToken = tokenXToken,
             engine = engine,
-            logger = logger
+            logger = logger,
+            ytelse = ytelse
         )
-        kafkaKonsumer.hentSøknad(søknad.søknadId, Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE).also {
+        kafkaKonsumer.hentSøknad(søknad.søknadId, ytelse).also {
             assertEquals(
                 søknad.somKomplettSøknad(søker, søknad.somK9Format(søker, metadata)),
                 it.data.somPleiepengerLivetsSluttfaseKomplettSøknad()
@@ -147,7 +149,8 @@ class PleiepengerLivetsSluttfaseTest {
             HttpStatusCode.BadRequest,
             jwtToken = tokenXToken,
             engine = engine,
-            logger = logger
+            logger = logger,
+            ytelse = Ytelse.PLEIEPENGER_LIVETS_SLUTTFASE
         )
     }
 }

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/endringsmelding/EndringsmeldingPleiepengerSyktBarnTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/endringsmelding/EndringsmeldingPleiepengerSyktBarnTest.kt
@@ -177,7 +177,8 @@ class EndringsmeldingPleiepengerSyktBarnTest {
             expectedResponse = null,
             requestEntity = endringsmelding,
             engine = engine,
-            logger = logger
+            logger = logger,
+            ytelse = Ytelse.ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN
         )
 
         hentOgAsserEndringsmelding(
@@ -350,7 +351,8 @@ class EndringsmeldingPleiepengerSyktBarnTest {
             """.trimIndent(),
             requestEntity = endringsmelding,
             engine = engine,
-            logger = logger
+            logger = logger,
+            ytelse = Ytelse.ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN
         )
     }
 
@@ -463,7 +465,8 @@ class EndringsmeldingPleiepengerSyktBarnTest {
             """.trimIndent(),
             requestEntity = endringsmelding,
             engine = engine,
-            logger = logger
+            logger = logger,
+            ytelse = Ytelse.ENDRINGSMELDING_PLEIEPENGER_SYKT_BARN
         )
 
         wireMockServer.stubSifInnsynApi(


### PR DESCRIPTION
Utleder ytelse fra X-K9-Brukerdialog header sendt fra frontend dialogene.
Sender med ytelse til k9-selvbetjening-oppslag for utledning av behandlingsnummer.