### PR TITLE
Legg til nytt optional felt for dine barn

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Barn.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/Barn.kt
@@ -1,0 +1,49 @@
+package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer
+import no.nav.k9brukerdialogapi.general.erFørEllerLik
+import no.nav.k9brukerdialogapi.general.erLikEllerEtter
+import no.nav.k9brukerdialogapi.general.krever
+import no.nav.k9brukerdialogapi.general.validerIdentifikator
+import java.time.LocalDate
+import no.nav.k9.søknad.felles.personopplysninger.Barn as K9Barn
+
+class Barn(
+    private var identitetsnummer: String? = null,
+    private val aktørId: String,
+    @JsonFormat(pattern = "yyyy-MM-dd") private val fødselsdato: LocalDate,
+    private val navn: String,
+    private val type: TypeBarn
+) {
+    companion object {
+        internal fun List<Barn>.somK9BarnListe() = map { it.somK9Barn() }
+        internal fun List<Barn>.valider(felt: String) = this.flatMapIndexed { index, barn ->
+            barn.valider("$felt[$index]")
+        }
+    }
+
+    internal fun valider(felt: String) = mutableListOf<String>().apply {
+        validerIdentifikator(identitetsnummer, "$felt.identitetsnummer")
+        krever(navn.isNotBlank(), "$felt.navn kan ikke være tomt eller blankt.")
+        krever(
+            fødselsdato.erLikEllerEtter(LocalDate.now().minusYears(19)),
+            "$felt.fødselsdato kan ikke være mer enn 19 år siden."
+        )
+        krever(
+            fødselsdato.erFørEllerLik(LocalDate.now()),
+            "$felt.fødselsdato kan ikke være i fremtiden."
+        )
+    }
+
+    internal fun somK9Barn() =
+        K9Barn().medNorskIdentitetsnummer(NorskIdentitetsnummer.of(identitetsnummer)).medFødselsdato(fødselsdato)
+
+}
+
+enum class TypeBarn {
+    FRA_OPPSLAG,
+    FOSTERBARN,
+    ANNET
+}
+

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/DineBarn.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/DineBarn.kt
@@ -1,0 +1,6 @@
+package no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene
+
+data class DineBarn(
+    val barn: List<Barn>,
+    val harDeltOmsorg: Boolean
+)

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerutbetalingArbeidstakerKomplettSøknad.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerutbetalingArbeidstakerKomplettSøknad.kt
@@ -20,6 +20,7 @@ class OmsorgspengerutbetalingArbeidstakerKomplettSøknad(
     private val bekreftelser: Bekreftelser,
     private val arbeidsgivere: List<Arbeidsgiver>,
     private val fosterbarn: List<Fosterbarn>? = null, // TODO: Fjern nullable når lansert
+    private val dineBarn: DineBarn? = null, // TODO: Fjern nullable når lansert
     private val hjemmePgaSmittevernhensyn: Boolean,
     private val hjemmePgaStengtBhgSkole: Boolean? = null,
     private val k9Format: Søknad

--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerutbetalingArbeidstakerSøknad.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerutbetalingArbeidstakerSøknad.kt
@@ -24,6 +24,7 @@ import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Bosted.Companion.valider
 import no.nav.k9brukerdialogapi.ytelse.fellesdomene.Opphold
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Arbeidsgiver.Companion.somK9Fraværsperiode
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Arbeidsgiver.Companion.valider
+import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Barn.Companion.somK9BarnListe
 import no.nav.k9brukerdialogapi.ytelse.omsorgspengerutbetalingarbeidstaker.domene.Fosterbarn.Companion.somK9BarnListe
 import java.net.URL
 import java.time.ZoneOffset
@@ -43,6 +44,7 @@ class OmsorgspengerutbetalingArbeidstakerSøknad(
     private val bekreftelser: Bekreftelser,
     private val arbeidsgivere: List<Arbeidsgiver>,
     private val fosterbarn: List<Fosterbarn>? = null, // TODO: Fjern nullable når lansert
+    private val dineBarn: DineBarn? = null,
     private val hjemmePgaSmittevernhensyn: Boolean,
     private val hjemmePgaStengtBhgSkole: Boolean? = null,
     private val dataBruktTilUtledningAnnetData: String? = null,
@@ -71,6 +73,7 @@ class OmsorgspengerutbetalingArbeidstakerSøknad(
             bosteder = bosteder,
             opphold = opphold,
             arbeidsgivere = arbeidsgivere,
+            dineBarn = dineBarn,
             fosterbarn = fosterbarn,
             bekreftelser = bekreftelser,
             vedleggId = vedlegg.map { it.vedleggId() },
@@ -88,7 +91,8 @@ class OmsorgspengerutbetalingArbeidstakerSøknad(
             mottatt,
             søker.somK9Søker(),
             OmsorgspengerUtbetaling(
-                fosterbarn?.somK9BarnListe(),
+                // TODO: Forenkle denne koden man har fjernet støtte for fosterbarn
+                if (!dineBarn?.barn.isNullOrEmpty()) dineBarn?.barn?.somK9BarnListe() else fosterbarn?.somK9BarnListe(),
                 OpptjeningAktivitet(),
                 arbeidsgivere.somK9Fraværsperiode(),
                 null,

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/omsorgspengerutbetalingarbeidstaker/domene/OmsorgspengerUtbetalingArbeidstakerSøknadTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertTrue
 class OmsorgspengerUtbetalingArbeidstakerSøknadTest {
 
     @Test
-    fun `K9Format blir som forventet`(){
+    fun `K9Format blir som forventet`() {
         val mottatt = ZonedDateTime.of(2022, 1, 2, 3, 4, 5, 6, ZoneId.of("UTC"))
         val søknadId = UUID.randomUUID().toString()
         val søknad = OmsorgspengerutbetalingArbeidstakerSøknad(
@@ -147,6 +147,18 @@ class OmsorgspengerUtbetalingArbeidstakerSøknadTest {
                 harBekreftetOpplysninger = true,
                 harForståttRettigheterOgPlikter = true
             ),
+            dineBarn = DineBarn(
+                harDeltOmsorg = false,
+                barn = listOf(
+                    Barn(
+                        identitetsnummer = "11223344567",
+                        aktørId = "1234567890",
+                        LocalDate.now(),
+                        "Barn Barnesen",
+                        TypeBarn.FRA_OPPSLAG
+                    )
+                ),
+            ),
             arbeidsgivere = listOf(
                 Arbeidsgiver(
                     navn = "Kiwi AS",
@@ -189,5 +201,51 @@ class OmsorgspengerUtbetalingArbeidstakerSøknadTest {
         }.also {
             assertTrue { it.message.toString().contains("Må ha minst en arbeidsgiver satt.") }
         }
+    }
+
+    @Test
+    fun `Gyldig søknad med dineBarn gir ingen feil`() {
+        OmsorgspengerutbetalingArbeidstakerSøknad(
+            språk = "nb",
+            vedlegg = listOf(),
+            bosteder = listOf(),
+            opphold = listOf(),
+            bekreftelser = Bekreftelser(
+                harBekreftetOpplysninger = true,
+                harForståttRettigheterOgPlikter = true
+            ),
+            dineBarn = DineBarn(
+                harDeltOmsorg = false,
+                barn = listOf(
+                    Barn(
+                        identitetsnummer = "11223344567",
+                        aktørId = "1234567890",
+                        LocalDate.now(),
+                        "Barn Barnesen",
+                        TypeBarn.FRA_OPPSLAG
+                    )
+                ),
+            ),
+            arbeidsgivere = listOf(
+                Arbeidsgiver(
+                    navn = "Kiwi AS",
+                    organisasjonsnummer = "825905162",
+                    utbetalingsårsak = Utbetalingsårsak.KONFLIKT_MED_ARBEIDSGIVER,
+                    konfliktForklaring = "Fordi blablabla",
+                    harHattFraværHosArbeidsgiver = true,
+                    arbeidsgiverHarUtbetaltLønn = true,
+                    perioder = listOf(
+                        Utbetalingsperiode(
+                            fraOgMed = LocalDate.parse("2022-01-25"),
+                            tilOgMed = LocalDate.parse("2022-01-28"),
+                            årsak = FraværÅrsak.SMITTEVERNHENSYN,
+                            aktivitetFravær = listOf(AktivitetFravær.ARBEIDSTAKER)
+                        )
+                    )
+                )
+            ),
+            hjemmePgaSmittevernhensyn = true,
+            hjemmePgaStengtBhgSkole = true
+        ).valider()
     }
 }


### PR DESCRIPTION
Vi skal legge til støtte for å sende inn litt mer informasjon om barn man har delt omsorg for i denne søknaden. Det krever at vi beveger oss vekk fra et felt for fosterbarn til et felt for dine barn generelt.

Denne endringen legger til støtte for å sende inn den informasjonen. [Ta en titt på denne PRen for endringene i frontend](https://github.com/navikt/sif-brukerdialog/pull/1830).