### PR TITLE
Legg til nytt spørsmål i ytelsen som sendes ut på Kafka

### DIFF
--- a/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/UtenlandsoppholdIPerioden.kt
+++ b/src/main/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/soknad/domene/UtenlandsoppholdIPerioden.kt
@@ -18,12 +18,13 @@ data class Utenlandsopphold(
     val landkode: String,
     val landnavn: String,
     val erUtenforEøs: Boolean?,
+    val erSammenMedBarnet: Boolean?,
     val erBarnetInnlagt: Boolean?,
     val perioderBarnetErInnlagt: List<Periode> = listOf(),
     val årsak: Årsak?,
 ) {
     override fun toString(): String {
-        return "Utenlandsopphold(fraOgMed=$fraOgMed, tilOgMed=$tilOgMed, landkode='$landkode', landnavn='$landnavn', erUtenforEos=$erUtenforEøs, erBarnetInnlagt=$erBarnetInnlagt, årsak=$årsak)"
+        return "Utenlandsopphold(fraOgMed=$fraOgMed, tilOgMed=$tilOgMed, landkode='$landkode', landnavn='$landnavn', erUtenforEos=$erUtenforEøs, erBarnetInnlagt=$erBarnetInnlagt, erSammenMedBarnet=$erSammenMedBarnet, årsak=$årsak)"
     }
 
     fun somUtenlandsoppholdPeriodeInfo() = UtenlandsoppholdPeriodeInfo()

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/SøknadUtils.kt
@@ -193,6 +193,7 @@ class SøknadUtils {
                             )
                         ),
                         erUtenforEøs = false,
+                        erSammenMedBarnet = false,
                         årsak = Årsak.BARNET_INNLAGT_I_HELSEINSTITUSJON_DEKKET_ETTER_AVTALE_MED_ET_ANNET_LAND_OM_TRYGD
                     ),
                     Utenlandsopphold(
@@ -208,6 +209,7 @@ class SøknadUtils {
                             )
                         ),
                         erUtenforEøs = false,
+                        erSammenMedBarnet = false,
                         årsak = Årsak.BARNET_INNLAGT_I_HELSEINSTITUSJON_FOR_NORSK_OFFENTLIG_REGNING
                     ),
                     Utenlandsopphold(
@@ -217,6 +219,7 @@ class SøknadUtils {
                         landnavn = "Sverige",
                         erBarnetInnlagt = false,
                         erUtenforEøs = false,
+                        erSammenMedBarnet = false,
                         årsak = null
                     )
                 )

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/SerDesTest.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/SerDesTest.kt
@@ -189,6 +189,7 @@ internal class SerDesTest {
                     "landnavn": "Sverige",
                     "erUtenforEøs": false,
                     "erBarnetInnlagt": true,
+                    "erSammenMedBarnet":  false,
                     "perioderBarnetErInnlagt" : [
                       {
                         "fraOgMed" : "2019-10-15",
@@ -204,6 +205,7 @@ internal class SerDesTest {
                     "tilOgMed": "2020-11-15",
                     "erUtenforEøs": false,
                     "erBarnetInnlagt": true,
+                    "erSammenMedBarnet":  false,
                     "perioderBarnetErInnlagt" : [
                       {
                         "fraOgMed" : "2020-11-10",
@@ -218,6 +220,7 @@ internal class SerDesTest {
                     "tilOgMed": "2022-12-20",
                     "erUtenforEøs": false,
                     "erBarnetInnlagt": false,
+                    "erSammenMedBarnet": false,
                     "perioderBarnetErInnlagt" : [],
                     "årsak": null
                   }
@@ -423,6 +426,7 @@ internal class SerDesTest {
                     "landnavn": "Sverige",
                     "erUtenforEøs": false,
                     "erBarnetInnlagt": true,
+                    "erSammenMedBarnet":  false,
                     "perioderBarnetErInnlagt" : [
                       {
                         "fraOgMed" : "2020-01-01",
@@ -438,6 +442,7 @@ internal class SerDesTest {
                     "tilOgMed": "2019-11-10",
                     "erUtenforEøs": false,
                     "erBarnetInnlagt": true,
+                    "erSammenMedBarnet":  false,
                     "perioderBarnetErInnlagt" : [
                       {
                         "fraOgMed" : "2020-01-01",
@@ -453,6 +458,7 @@ internal class SerDesTest {
                     "tilOgMed": "2019-11-10",
                     "erUtenforEøs": false,
                     "erBarnetInnlagt": true,
+                    "erSammenMedBarnet":  false,
                     "perioderBarnetErInnlagt" : [
                       {
                         "fraOgMed" : "2020-01-01",
@@ -467,6 +473,7 @@ internal class SerDesTest {
                     "tilOgMed": "2019-11-10",
                     "erUtenforEøs": false,
                     "erBarnetInnlagt": false,
+                    "erSammenMedBarnet":  false,
                     "perioderBarnetErInnlagt" : [],
                     "årsak": null
                   }
@@ -685,6 +692,7 @@ internal class SerDesTest {
                             )
                         ),
                         erUtenforEøs = false,
+                        erSammenMedBarnet = false,
                         årsak = Årsak.ANNET
                     ),
                     Utenlandsopphold(
@@ -700,6 +708,7 @@ internal class SerDesTest {
                             )
                         ),
                         erUtenforEøs = false,
+                        erSammenMedBarnet = false,
                         årsak = Årsak.BARNET_INNLAGT_I_HELSEINSTITUSJON_FOR_NORSK_OFFENTLIG_REGNING
                     ),
                     Utenlandsopphold(
@@ -715,6 +724,7 @@ internal class SerDesTest {
                             )
                         ),
                         erUtenforEøs = false,
+                        erSammenMedBarnet = false,
                         årsak = Årsak.BARNET_INNLAGT_I_HELSEINSTITUSJON_DEKKET_ETTER_AVTALE_MED_ET_ANNET_LAND_OM_TRYGD
                     ),
                     Utenlandsopphold(
@@ -724,6 +734,7 @@ internal class SerDesTest {
                         landnavn = "Sverige",
                         erBarnetInnlagt = false,
                         erUtenforEøs = false,
+                        erSammenMedBarnet = false,
                         årsak = null
                     )
                 )

--- a/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/k9Format/K9FormatUtenlandsopphold.kt
+++ b/src/test/kotlin/no/nav/k9brukerdialogapi/ytelse/pleiepengersyktbarn/domene/k9Format/K9FormatUtenlandsopphold.kt
@@ -23,6 +23,7 @@ class K9FormatUtenlandsopphold {
                     landnavn = "Tyskland",
                     erUtenforEøs = false,
                     erBarnetInnlagt = true,
+                    erSammenMedBarnet = false,
                     perioderBarnetErInnlagt = listOf(
                         Periode(
                             fraOgMed = LocalDate.parse("2022-01-05"),
@@ -69,6 +70,7 @@ class K9FormatUtenlandsopphold {
                     landnavn = "Tyskland",
                     erUtenforEøs = false,
                     erBarnetInnlagt = true,
+                    erSammenMedBarnet = false,
                     perioderBarnetErInnlagt = listOf(
                         Periode(
                             fraOgMed = LocalDate.parse("2022-01-01"),
@@ -107,6 +109,7 @@ class K9FormatUtenlandsopphold {
                     landnavn = "Tyskland",
                     erUtenforEøs = false,
                     erBarnetInnlagt = true,
+                    erSammenMedBarnet = false,
                     perioderBarnetErInnlagt = listOf(
                         Periode(
                             fraOgMed = LocalDate.parse("2022-01-01"),
@@ -157,6 +160,7 @@ class K9FormatUtenlandsopphold {
                     landnavn = "Tyskland",
                     erUtenforEøs = false,
                     erBarnetInnlagt = true,
+                    erSammenMedBarnet = false,
                     perioderBarnetErInnlagt = listOf(
                         Periode(
                             fraOgMed = LocalDate.parse("2022-01-03"),


### PR DESCRIPTION
Vi spør om et nytt spørsmål for pleiepenger sykt barn når man reiser utenlands. For er man egentlig med barnet når barnet er innlagt? Dette trenger vi å finne ut av. 

Vi tar imot det nye boolske flagget, og sender det videre til Kafka-køen for prosessering.

Se også denne PRen for hva som skjer på andre siden av køen: https://github.com/navikt/k9-brukerdialog-prosessering/pull/172